### PR TITLE
Bump project version to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ scenarios.
 ```kotlin
 // build.gradle.kts
 plugins {
-    id("com.konfigyr.artifactory") version "1.0.0"
+    id("com.konfigyr.artifactory") version "1.1.0"
 }
 ```
 
 ```groovy
 // build.gradle
 plugins {
-    id 'com.konfigyr.artifactory' version '1.0.0'
+    id 'com.konfigyr.artifactory' version '1.1.0'
 }
 ```
 
@@ -228,7 +228,7 @@ Apply the plugin selectively and share the common configuration at the root:
 // root build.gradle.kts                                                                                                                                                                                                                              
 
 plugins {
-    id("com.konfigyr.artifactory") version "1.0.0" apply false
+    id("com.konfigyr.artifactory") version "1.1.0" apply false
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ subprojects {
     }
 
     group = "com.konfigyr"
-    version = "1.0.0"
+    version = "1.1.0"
 
     java {
         withJavadocJar()

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/ArtifactMetadataScanner.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/ArtifactMetadataScanner.java
@@ -22,7 +22,7 @@ import java.util.zip.ZipFile;
  * configuration metadata", shared by every place in the build that needs to answer that question.
  *
  * @author Vladimir Spasic
- * @since 1.0.0
+ * @since 1.1.0
  */
 @NullMarked
 public final class ArtifactMetadataScanner {

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/ClientCredentials.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/ClientCredentials.java
@@ -18,7 +18,7 @@ import java.util.Objects;
  * @param clientSecret the OAuth2 {@code client_secret} known only to the client and the identity
  *                     provider, never {@literal null}.
  * @author Vladimir Spasic
- * @since 1.0.0
+ * @since 1.1.0
  * @see Credentials
  */
 @NullMarked

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/Credentials.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/Credentials.java
@@ -21,7 +21,7 @@ import java.io.Serializable;
  * requesting the access token, regardless of which grant is actually used to obtain it.
  *
  * @author Vladimir Spasic
- * @since 1.0.0
+ * @since 1.1.0
  * @see ClientCredentials
  * @see TokenExchange
  */

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/TokenExchange.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/TokenExchange.java
@@ -21,7 +21,7 @@ import java.util.Objects;
  *                         {@code subjectToken} (for example {@code urn:ietf:params:oauth:token-type:jwt}
  *                         or {@code urn:ietf:params:oauth:token-type:id_token}), never {@literal null}.
  * @author Vladimir Spasic
- * @since 1.0.0
+ * @since 1.1.0
  * @see Credentials
  */
 @NullMarked

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/CreateServiceReleaseTask.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/CreateServiceReleaseTask.java
@@ -29,7 +29,7 @@ import java.util.List;
  * this task is registered with in {@link KonfigyrPlugin}.
  *
  * @author Vladimir Spasic
- * @since 1.0.0
+ * @since 1.1.0
  */
 @DisableCachingByDefault(because = "Performs a network call against a stateful remote service")
 public abstract class CreateServiceReleaseTask extends DefaultTask {

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/GenerateArtifactMetadataTask.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/GenerateArtifactMetadataTask.java
@@ -28,7 +28,7 @@ import java.util.List;
  * that artifact as absent.
  *
  * @author Vladimir Spasic
- * @since 1.0.0
+ * @since 1.1.0
  */
 @CacheableTask
 public abstract class GenerateArtifactMetadataTask extends DefaultTask {

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrExtension.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrExtension.java
@@ -239,7 +239,7 @@ public class KonfigyrExtension {
      * defined by <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.4">RFC 6749, Section 4.4</a>.
      *
      * @author Vladimir Spasic
-     * @since 1.0.0
+     * @since 1.1.0
      * @see KonfigyrExtension#clientCredentials(Action)
      */
     @Getter
@@ -283,7 +283,7 @@ public class KonfigyrExtension {
      * <a href="https://datatracker.ietf.org/doc/html/rfc8693">RFC 8693</a>.
      *
      * @author Vladimir Spasic
-     * @since 1.0.0
+     * @since 1.1.0
      * @see KonfigyrExtension#tokenExchange(Action)
      */
     @Getter
@@ -338,7 +338,7 @@ public class KonfigyrExtension {
      * with no {@link #namespace} configured skips it entirely.
      *
      * @author Vladimir Spasic
-     * @since 1.0.0
+     * @since 1.1.0
      * @see KonfigyrExtension#service(Action)
      */
     @Getter
@@ -370,7 +370,7 @@ public class KonfigyrExtension {
      * {@code PublishArtifactMetadataTask} uploads this project's own artifact metadata.
      *
      * @author Vladimir Spasic
-     * @since 1.0.0
+     * @since 1.1.0
      * @see KonfigyrExtension#publish(Action)
      */
     @Getter

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ResolveServiceDependenciesTask.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ResolveServiceDependenciesTask.java
@@ -40,7 +40,7 @@ import java.util.List;
  * {@code com.konfigyr-konfigyr-artifactory-1.0.0.json}
  *
  * @author Vladimir Spasic
- * @since 1.0.0
+ * @since 1.1.0
  */
 @CacheableTask
 public abstract class ResolveServiceDependenciesTask extends DefaultTask {

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ServiceReleaseArtifactUploadAction.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ServiceReleaseArtifactUploadAction.java
@@ -13,7 +13,7 @@ import org.jspecify.annotations.NonNull;
  * required by a {@link ServiceRelease} using the registered {@link ArtifactoryService}.
  *
  * @author Vladimir Spasic
- * @since 1.0.0
+ * @since 1.1.0
  */
 public abstract class ServiceReleaseArtifactUploadAction implements WorkAction<ServiceReleaseArtifactUploadAction.Parameters> {
 


### PR DESCRIPTION
## Summary
- Bump the project version from `1.0.0` to `1.1.0` in `build.gradle.kts` and update the matching `com.konfigyr.artifactory` plugin-version examples in `README.md`.
- Update `@since` javadoc tags to `1.1.0` for:  `Credentials`, `ClientCredentials`, `TokenExchange`, `ArtifactMetadataScanner` and the new `KonfigyrExtension` nested spec types (`ClientCredentialsSpec`, `TokenExchangeSpec`, `ServiceSpec`, `PublishSpec`)