### PR TITLE
Audit and fix Javadoc across core, gradle, and test-support modules

### DIFF
--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/ArtifactMetadataParser.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/ArtifactMetadataParser.java
@@ -121,6 +121,13 @@ public class ArtifactMetadataParser {
                 .build();
     }
 
+    /**
+     * Converts the Spring Boot {@code deprecation} metadata, if present, into a Konfigyr
+     * {@link Deprecation}.
+     *
+     * @param metadata the Spring Boot configuration metadata property, cannot be {@literal null}.
+     * @return the resolved deprecation, or {@literal null} if the property is not deprecated.
+     */
     @Nullable
     static Deprecation resolveDeprecation(ConfigurationMetadataProperty metadata) {
         if (metadata.getDeprecation() == null) {
@@ -132,6 +139,13 @@ public class ArtifactMetadataParser {
         );
     }
 
+    /**
+     * Resolves the Spring Boot {@code defaultValue} metadata, if present, to its string
+     * representation, joining collection or array values with {@code ", "}.
+     *
+     * @param metadata the Spring Boot configuration metadata property, cannot be {@literal null}.
+     * @return the resolved default value, or {@literal null} if absent or blank.
+     */
     @Nullable
     static String resolveDefaultValue(ConfigurationMetadataProperty metadata) {
         final Object defaultValue = metadata.getDefaultValue();

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/ArtifactoryClient.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/ArtifactoryClient.java
@@ -200,6 +200,8 @@ public interface ArtifactoryClient {
      *
      * @param artifact the artifact for which the publication should be checked, never {@literal null}.
      * @return {@literal true} if the artifact version is published, {@literal false} otherwise.
+     * @throws HttpResponseException if the response is not a {@code 404} or {@code 2xx} status, or
+     *                                communication with the API fails or authentication is invalid.
      */
     boolean isPublished(Artifact artifact);
 

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/ByteArrayArtifactMetadataResource.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/ByteArrayArtifactMetadataResource.java
@@ -5,12 +5,26 @@ import org.jspecify.annotations.NullMarked;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
+/**
+ * {@link ArtifactMetadataResource} backed by an in-memory byte array, for metadata that has already
+ * been read into memory (e.g. extracted from a JAR entry) rather than living on the filesystem.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see ArtifactMetadataResource#of(String, byte[])
+ */
 @NullMarked
 final class ByteArrayArtifactMetadataResource implements ArtifactMetadataResource {
 
     private final String name;
     private final byte[] contents;
 
+    /**
+     * Creates a new {@link ByteArrayArtifactMetadataResource}.
+     *
+     * @param name a descriptive name for the resource, cannot be {@literal null}.
+     * @param contents the raw bytes of the Spring Boot configuration metadata, cannot be {@literal null}.
+     */
     public ByteArrayArtifactMetadataResource(String name, byte[] contents) {
         this.name = name;
         this.contents = contents;

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/DefaultOAuthClientCredentialsProvider.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/DefaultOAuthClientCredentialsProvider.java
@@ -124,6 +124,15 @@ final class DefaultOAuthClientCredentialsProvider implements OAuthClientCredenti
         }
     }
 
+    /**
+     * Extracts and maps the value node found under the given key, if present and a JSON value node
+     * (not an object or array).
+     *
+     * @param node the JSON node to look up the key in, cannot be {@literal null}.
+     * @param key the field name to look up, cannot be {@literal null}.
+     * @param mapper maps the found value node to the desired type, cannot be {@literal null}.
+     * @return the mapped value, or {@link Optional#empty()} if the key is absent or not a value node.
+     */
     static <T> Optional<T> getNodeValue(JsonNode node, String key, Function<JsonNode, T> mapper) {
         return Optional.ofNullable(node.get(key))
                 .filter(JsonNode::isValueNode)

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/FileArtifactMetadataResource.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/FileArtifactMetadataResource.java
@@ -7,11 +7,23 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.*;
 
+/**
+ * {@link ArtifactMetadataResource} backed by a file on the filesystem.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see ArtifactMetadataResource#of(Path)
+ */
 @NullMarked
 final class FileArtifactMetadataResource implements ArtifactMetadataResource {
 
     private final Path file;
 
+    /**
+     * Creates a new {@link FileArtifactMetadataResource}.
+     *
+     * @param file the path to the file containing Spring Boot configuration metadata, cannot be {@literal null}.
+     */
     FileArtifactMetadataResource(Path file) {
         this.file = file;
     }

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/HttpResponseException.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/HttpResponseException.java
@@ -9,8 +9,8 @@ import java.net.http.HttpResponse;
 /**
  * Exception that is thrown when a non-ok HTTP response is received.
  *
- * @author : vladimir.spasic@ebf.com
- * @since : 02.10.22, Sun
+ * @author Vladimir Spasic
+ * @since 1.0.0
  **/
 public class HttpResponseException extends RuntimeException {
 

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/ResolvedPropertyType.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/ResolvedPropertyType.java
@@ -26,7 +26,14 @@ public class ResolvedPropertyType implements Serializable {
     @Serial
     private static final long serialVersionUID = -7621006446277743496L;
 
+    /**
+     * Shared {@link TypeResolver} used to resolve every {@link ResolvedPropertyType} created by this class.
+     */
     static final TypeResolver TYPE_RESOLVER = new TypeResolver();
+
+    /**
+     * The fallback type used when a property's type name cannot be resolved to an actual Java type.
+     */
     static final ResolvedPropertyType STRING_TYPE = new ResolvedPropertyType(String.class);
 
     /**

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/Transport.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/Transport.java
@@ -43,6 +43,12 @@ final class Transport {
     private final TransportOptions options;
     private final HttpClient client;
 
+    /**
+     * Creates a new {@link Transport}, building its own {@link HttpClient} from the given
+     * {@link TransportOptions}.
+     *
+     * @param options the transport options, cannot be {@literal null}.
+     */
     Transport(TransportOptions options) {
         this.options = Objects.requireNonNull(options, "Transport options must not be null");
         this.client = HttpClient.newBuilder()

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/TypeNameResolver.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/TypeNameResolver.java
@@ -35,7 +35,10 @@ import java.util.concurrent.ConcurrentHashMap;
  **/
 final class TypeNameResolver {
 
-    // the type used to represent an unknown type in the cache
+    /**
+     * Sentinel cached under a class name that could not be resolved, so a repeated lookup for the same
+     * unresolvable name returns {@literal null} again without retrying the resolution.
+     */
     static final ResolvedPropertyType UNKNOWN_TYPE = new ResolvedPropertyType(TypeNameResolver.class);
 
     static final Logger logger = LoggerFactory.getLogger(TypeNameResolver.class);
@@ -153,6 +156,13 @@ final class TypeNameResolver {
         throw new ClassNotFoundException("Could not resolve type for: " + type);
     }
 
+    /**
+     * Converts a {@code classmate} {@link ResolvedType} into a {@link ResolvedPropertyType}, recursively
+     * converting its generic type parameters, if any.
+     *
+     * @param type the resolved type to convert, cannot be {@literal null}.
+     * @return the converted resolved property type, never {@literal null}.
+     */
     @NonNull
     static ResolvedPropertyType createResolvedType(@NonNull ResolvedType type) {
         final List<ResolvedPropertyType> parameters = new ArrayList<>();

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/schema/DefaultJsonSchemaGenerator.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/schema/DefaultJsonSchemaGenerator.java
@@ -23,6 +23,9 @@ import java.util.*;
  * This is intentionally basic: it covers primitives, wrappers, strings, numbers, booleans,
  * enums, arrays, collections, maps, and simple POJOs (by inspecting their declared fields).
  * It emits Draft 2020-12 compatible keywords (type, properties, items, additionalProperties, required, enum, format).
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
  */
 final class DefaultJsonSchemaGenerator implements JsonSchemaGenerator {
 
@@ -32,6 +35,13 @@ final class DefaultJsonSchemaGenerator implements JsonSchemaGenerator {
     private final TypeResolver typeResolver;
     private final List<SchemaDefinitionProvider<?, ?>> providers;
 
+    /**
+     * Creates a new {@link DefaultJsonSchemaGenerator}, using the given {@link TypeLoader} and
+     * {@link TypeResolver} to build its {@link SchemaDefinitionProvider}s.
+     *
+     * @param typeLoader the type loader to use, cannot be {@literal null}.
+     * @param typeResolver the type resolver to use, cannot be {@literal null}.
+     */
     DefaultJsonSchemaGenerator(TypeLoader typeLoader, TypeResolver typeResolver) {
         this.typeLoader = typeLoader;
         this.typeResolver = typeResolver;

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/schema/PrimitiveSchemaDefinitionProvider.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/schema/PrimitiveSchemaDefinitionProvider.java
@@ -28,6 +28,13 @@ final class PrimitiveSchemaDefinitionProvider<T extends JsonSchema, B extends Js
 
     private final Set<PrimitiveSchemaDefinition> definitions;
 
+    /**
+     * Creates a new {@link PrimitiveSchemaDefinitionProvider}, building its fixed set of known
+     * primitive/wrapper/well-known type definitions via {@link #createDefinitions(TypeLoader)}.
+     *
+     * @param loader the type loader used to resolve each known type against the target classpath,
+     *               cannot be {@literal null}.
+     */
     PrimitiveSchemaDefinitionProvider(TypeLoader loader) {
         definitions = createDefinitions(loader);
     }
@@ -75,6 +82,15 @@ final class PrimitiveSchemaDefinitionProvider<T extends JsonSchema, B extends Js
                 .findFirst();
     }
 
+    /**
+     * Builds the fixed set of {@link PrimitiveSchemaDefinition}s this provider matches against -
+     * primitives, wrappers, strings, {@code java.time} types, and other well-known JDK/Spring types
+     * with a natural JSON Schema representation.
+     *
+     * @param loader the type loader used to resolve each known type against the target classpath,
+     *               cannot be {@literal null}.
+     * @return the built definitions, never {@literal null}.
+     */
     static Set<PrimitiveSchemaDefinition> createDefinitions(TypeLoader loader) {
         final Set<PrimitiveSchemaDefinition> definitions = new LinkedHashSet<>();
 

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/schema/PropertyCandidate.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/schema/PropertyCandidate.java
@@ -12,6 +12,15 @@ import java.lang.reflect.Modifier;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
+/**
+ * A single declared field of a POJO being turned into an {@code object} JSON Schema by
+ * {@link DefaultJsonSchemaGenerator}, paired with its JavaBeans getter (if one can be found), used
+ * to read annotations that may be declared on the getter rather than the field itself (e.g.
+ * {@link Deprecated}).
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
 @EqualsAndHashCode
 final class PropertyCandidate implements Comparable<PropertyCandidate> {
 
@@ -21,33 +30,73 @@ final class PropertyCandidate implements Comparable<PropertyCandidate> {
     @Nullable
     private final Method getter;
 
+    /**
+     * Creates a new {@link PropertyCandidate} for the given field, locating its JavaBeans getter, if
+     * any, via {@link #findGetter(Class, Field)}.
+     *
+     * @param type the resolved type the field is declared on, cannot be {@literal null}.
+     * @param field the field this candidate wraps, cannot be {@literal null}.
+     * @throws ReflectiveOperationException if the getter lookup fails.
+     */
     PropertyCandidate(@NonNull ResolvedType type, @NonNull Field field) throws ReflectiveOperationException {
         this.field = field;
         this.getter = findGetter(type.getErasedType(), field);
     }
 
+    /**
+     * The field's name, used as the JSON Schema property name.
+     *
+     * @return the field name, never {@literal null}.
+     */
     @NonNull
     String getName() {
         return field.getName();
     }
 
+    /**
+     * The field's declared type, used to generate its JSON Schema.
+     *
+     * @return the field type, never {@literal null}.
+     */
     @NonNull
     Class<?> getType() {
         return field.getType();
     }
 
+    /**
+     * Checks whether this field is declared {@code transient}, excluding it from the generated schema.
+     *
+     * @return {@literal true} if the field is transient.
+     */
     boolean isTransient() {
         return Modifier.isTransient(field.getModifiers());
     }
 
+    /**
+     * Checks whether this field is declared {@code static}, excluding it from the generated schema.
+     *
+     * @return {@literal true} if the field is static.
+     */
     boolean isStatic() {
         return Modifier.isStatic(field.getModifiers());
     }
 
+    /**
+     * Checks whether this field should be marked as a required property, currently always the case
+     * for primitive types, which cannot themselves represent absence.
+     *
+     * @return {@literal true} if the field is required.
+     */
     boolean isRequired() {
         return getType().isPrimitive();
     }
 
+    /**
+     * Checks whether this field, or its {@link #findGetter(Class, Field) getter}, is annotated
+     * {@link Deprecated}.
+     *
+     * @return {@literal true} if the field is deprecated.
+     */
     boolean isDeprecated() {
         return annotationFor(Deprecated.class) != null;
     }
@@ -67,6 +116,16 @@ final class PropertyCandidate implements Comparable<PropertyCandidate> {
         return annotation;
     }
 
+    /**
+     * Looks up the JavaBeans-style getter for the given field, trying every plausible getter name in
+     * turn, or the field's own name directly for a {@link Class#isRecord() record} component.
+     *
+     * @param type the type the field is declared on, cannot be {@literal null}.
+     * @param field the field to find a getter for, cannot be {@literal null}.
+     * @return the found getter method, or {@literal null} if none of the candidate names match a
+     *         public method.
+     * @throws ReflectiveOperationException if the record component accessor cannot be found.
+     */
     static Method findGetter(Class<?> type, Field field) throws ReflectiveOperationException {
         // "non-prefix" naming convention of Java 14 java.lang.Record types
         if (type.isRecord()) {

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/schema/SchemaGenerationContext.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/schema/SchemaGenerationContext.java
@@ -29,6 +29,9 @@ import java.util.function.Predicate;
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public final class SchemaGenerationContext {
 
+    /**
+     * The Spring Boot configuration metadata property this context is generating a schema for.
+     */
     @Getter
     private final ConfigurationMetadataProperty configurationMetadataProperty;
     private final TypeResolver typeResolver;

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ArtifactMetadataTransform.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ArtifactMetadataTransform.java
@@ -114,8 +114,16 @@ public abstract class ArtifactMetadataTransform implements TransformAction<Artif
         }
     }
 
+    /**
+     * Transform parameters for {@link ArtifactMetadataTransform}.
+     */
     interface Parameters extends TransformParameters {
 
+        /**
+         * The shared {@link ArtifactoryService} used to generate the property descriptor metadata.
+         *
+         * @return the artifactory service to use, never {@literal null}.
+         */
         @Internal
         Property<ArtifactoryService> getService();
 

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ArtifactoryService.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ArtifactoryService.java
@@ -28,10 +28,13 @@ import java.util.stream.StreamSupport;
 /**
  * Gradle {@link BuildService} for interacting with the Konfigyr Artifactory REST API.
  * <p>
+ * Registered once, exactly, for the whole build via {@code registerIfAbsent} and shared
+ * across every project and task that needs it, rather than one instance per project.
  * Builds one {@link ArtifactoryClient} per configured {@link Registry}, all sharing a single
  * {@link ArtifactoryClientFactory}, and therefore a single connection pool and a single
  * token/discovery cache. Every method that talks to a registry takes its name as the first
- * argument to select which of those clients to use.
+ * argument to select which of those clients to use, this service itself is keyed by the
+ * registry name rather than bound to a single one.
  *
  * @author Vladimir Spasic
  * @since 1.0.0
@@ -63,6 +66,12 @@ public abstract class ArtifactoryService implements BuildService<ArtifactoryServ
         this.clients = Collections.unmodifiableMap(clients);
     }
 
+    /**
+     * Creates a new {@link ArtifactoryService} instance with a pre-built set of clients, bypassing the
+     * usual {@link Parameters}-driven construction. Only intended for tests.
+     *
+     * @param clients the clients to use, keyed by registry name, cannot be {@literal null}.
+     */
     @VisibleForTesting
     ArtifactoryService(Map<String, ArtifactoryClient> clients) {
         this.mapper = ArtifactoryClientFactory.createDefaultJsonMapper();
@@ -373,12 +382,25 @@ public abstract class ArtifactoryService implements BuildService<ArtifactoryServ
         return artifact.groupId() + joiner + artifact.artifactId() + joiner + artifact.version();
     }
 
+    /**
+     * Build service parameters for {@link ArtifactoryService}, resolved once, lazily, when the shared
+     * service is first realized. See {@link KonfigyrPlugin} for how these are populated.
+     */
     interface Parameters extends BuildServiceParameters {
 
+        /**
+         * Every {@link Registry} to build a client for, keyed by registry name.
+         *
+         * @return the registry configurations, never {@literal null}.
+         */
         MapProperty<String, Registry> getConfigurations();
 
     }
 
+    /**
+     * Exponential backoff calculator used by {@link #publish(String, ArtifactMetadata, Duration, Duration)}
+     * while polling for a {@link Publication} to leave the {@code PENDING} state.
+     */
     static final class BackOffExecution {
         static final long STOP = -1;
 
@@ -388,11 +410,23 @@ public abstract class ArtifactoryService implements BuildService<ArtifactoryServ
         private long elapsed = 0;
         private int attempts = 0;
 
+        /**
+         * Creates a new {@link BackOffExecution}.
+         *
+         * @param interval the initial time interval, in milliseconds, between polling attempts.
+         * @param timeout the overall time budget, in milliseconds, allowed for polling.
+         */
         BackOffExecution(long interval, long timeout) {
             this.interval = interval;
             this.timeout = timeout;
         }
 
+        /**
+         * Returns the number of milliseconds to wait before the next polling attempt, or {@link #STOP}
+         * once the timeout has been exceeded or too many attempts have been made.
+         *
+         * @return the next backoff delay in milliseconds, or {@link #STOP}.
+         */
         long nextBackOff() {
             // we reached the max attempts, or the timeout is exceeded, stop polling...
             if (elapsed >= timeout || attempts >= 60) {

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/CreateServiceReleaseTask.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/CreateServiceReleaseTask.java
@@ -114,10 +114,10 @@ public abstract class CreateServiceReleaseTask extends DefaultTask {
     public abstract Property<@NonNull String> getServiceName();
 
     /**
-     * Whether this task is eligible to run: the project's {@code konfigyr { service { } } }} block has
+     * Whether this task is eligible to run: the project's {@code konfigyr { service { } }} block has
      * been configured, <em>and</em> the registry named by {@link #getRegistryName()} is fully
-     * configured (a {@code url} and either {@code clientCredentials { } } }} or
-     * {@code tokenExchange { } } }} grant). See the {@code onlyIf} predicate this task is registered
+     * configured (a {@code url} and either {@code clientCredentials { }} or
+     * {@code tokenExchange { }} grant). See the {@code onlyIf} predicate this task is registered
      * with in {@link KonfigyrPlugin}.
      *
      * @return {@literal true} if this task should run.

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrExtension.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrExtension.java
@@ -232,6 +232,9 @@ public class KonfigyrExtension {
          */
         private final Property<String> name;
 
+        /**
+         * Whether {@link KonfigyrExtension#service(Action)} was ever called for this project.
+         */
         private boolean configured;
 
         ServiceSpec(ObjectFactory factory, String projectName) {
@@ -249,6 +252,10 @@ public class KonfigyrExtension {
             return configured;
         }
 
+        /**
+         * Marks this service identity as configured, called once {@link KonfigyrExtension#service(Action)}
+         * has executed the given action against this instance.
+         */
         void markConfigured() {
             configured = true;
         }

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrPlugin.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrPlugin.java
@@ -22,14 +22,18 @@ import java.time.Duration;
 import java.util.*;
 
 /**
- * Gradle plugin for Konfigyr Artifacts.
+ * Gradle plugin for publishing Spring Boot configuration metadata to Konfigyr.
  * <p>
- * This plugin provides a {@code konfigyr} task for uploading Spring Boot configuration metadata to Konfigyr.
+ * Registers a {@code konfigyr} meta-task, and one publish/release task pair per registry declared in
+ * the {@link KonfigyrExtension#getRegistries() registries} container - there is no single "the"
+ * registry or connection, every declared registry gets its own task pair and its own {@link Registry}
+ * connection, keyed by registry name.
  * <p>
  * You can configure the plugin using the {@code konfigyr} extension.
  *
  * @author Vladimir Spasic
  * @since 1.0.0
+ * @see KonfigyrExtension
  **/
 public class KonfigyrPlugin implements Plugin<@NonNull Project> {
 

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/PublishArtifactMetadataTask.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/PublishArtifactMetadataTask.java
@@ -66,7 +66,7 @@ public abstract class PublishArtifactMetadataTask extends DefaultTask {
 
     /**
      * Whether the registry named by {@link #getRegistryName()} is fully configured (a {@code url} and
-     * either {@code clientCredentials { } } }} or {@code tokenExchange { } } }} grant). See the
+     * either {@code clientCredentials { }} or {@code tokenExchange { }} grant). See the
      * {@code onlyIf} predicate this task is registered with in {@link KonfigyrPlugin}.
      *
      * @return {@literal true} if this task should run.

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/RegistrySpec.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/RegistrySpec.java
@@ -73,6 +73,12 @@ import java.net.URI;
 @NullMarked
 public class RegistrySpec implements Named {
 
+    /**
+     * The name under which this registry is declared in the {@code registries { } } container -
+     * either the reserved {@value KonfigyrExtension#CENTRAL_REGISTRY_NAME} name, or a custom name
+     * passed to {@link KonfigyrExtension#registry(String, Action)}. Also used to derive this
+     * registry's per-registry Gradle task names (e.g. {@code publishArtifactMetadataToStaging}).
+     */
     private final String name;
 
     /**
@@ -100,6 +106,18 @@ public class RegistrySpec implements Named {
     @Nullable
     private TokenExchangeSpec tokenExchange;
 
+    /**
+     * Creates a new {@link RegistrySpec}, instantiated by Gradle for each entry added to the
+     * {@link KonfigyrExtension#getRegistries()} container.
+     *
+     * @param name the registry name, cannot be {@literal null}.
+     * @param objects the Gradle object factory, cannot be {@literal null}.
+     * @param providers the Gradle provider factory, used to resolve environment variable conventions,
+     *                   cannot be {@literal null}.
+     * @param useEnvironmentConventions {@literal true} only for the reserved
+     *                                   {@value KonfigyrExtension#CENTRAL_REGISTRY_NAME} registry,
+     *                                   enabling its environment variable fallbacks.
+     */
     @Inject
     public RegistrySpec(String name, ObjectFactory objects, ProviderFactory providers, boolean useEnvironmentConventions) {
         this.name = name;
@@ -230,8 +248,25 @@ public class RegistrySpec implements Named {
          */
         private final Property<String> clientSecret;
 
+        /**
+         * Whether this grant falls back to Konfigyr's well-known environment variables
+         * ({@code KONFIGYR_CLIENT_ID}/{@code KONFIGYR_CLIENT_SECRET}) when a property is left unset -
+         * {@literal true} only for the reserved {@value KonfigyrExtension#CENTRAL_REGISTRY_NAME}
+         * registry, every other registry must set every property explicitly.
+         */
         private final boolean useEnvironmentConventions;
 
+        /**
+         * Creates a new {@link ClientCredentialsSpec}, instantiated by Gradle when
+         * {@link RegistrySpec#clientCredentials(Action)} is first called for a given registry.
+         *
+         * @param factory the Gradle object factory, cannot be {@literal null}.
+         * @param providers the Gradle provider factory, used to resolve environment variable
+         *                   conventions, cannot be {@literal null}.
+         * @param useEnvironmentConventions {@literal true} only for the reserved
+         *                                   {@value KonfigyrExtension#CENTRAL_REGISTRY_NAME} registry,
+         *                                   enabling its environment variable fallbacks.
+         */
         @Inject
         public ClientCredentialsSpec(ObjectFactory factory, ProviderFactory providers, boolean useEnvironmentConventions) {
             this.useEnvironmentConventions = useEnvironmentConventions;
@@ -245,10 +280,24 @@ public class RegistrySpec implements Named {
             }
         }
 
+        /**
+         * Checks whether both {@link #clientId} and {@link #clientSecret} are present, either set
+         * directly or resolved from their environment variable conventions.
+         *
+         * @return {@literal true} if this grant is fully configured.
+         */
         boolean isConfigured() {
             return clientId.isPresent() && clientSecret.isPresent();
         }
 
+        /**
+         * Creates the {@link ClientCredentials} described by this specification.
+         * <p>
+         * Callers must have already verified {@link #isConfigured()} returns {@literal true} before
+         * calling this method, since it eagerly resolves every required property and fails otherwise.
+         *
+         * @return the credentials, never {@literal null}.
+         */
         Credentials toCredentials() {
             KonfigyrExtension.assertPropertySet(clientId, "clientId", environmentVariableHint("KONFIGYR_CLIENT_ID"));
             KonfigyrExtension.assertPropertySet(clientSecret, "clientSecret", environmentVariableHint("KONFIGYR_CLIENT_SECRET"));
@@ -298,8 +347,26 @@ public class RegistrySpec implements Named {
          */
         private final Property<String> subjectTokenType;
 
+        /**
+         * Whether this grant falls back to Konfigyr's well-known environment variables
+         * ({@code KONFIGYR_CLIENT_ID}/{@code KONFIGYR_SUBJECT_TOKEN}) when a property is left unset -
+         * {@literal true} only for the reserved {@value KonfigyrExtension#CENTRAL_REGISTRY_NAME}
+         * registry, every other registry must set every property explicitly. Note that
+         * {@link #subjectTokenType} never falls back to an environment variable, even here.
+         */
         private final boolean useEnvironmentConventions;
 
+        /**
+         * Creates a new {@link TokenExchangeSpec}, instantiated by Gradle when
+         * {@link RegistrySpec#tokenExchange(Action)} is first called for a given registry.
+         *
+         * @param factory the Gradle object factory, cannot be {@literal null}.
+         * @param providers the Gradle provider factory, used to resolve environment variable
+         *                   conventions, cannot be {@literal null}.
+         * @param useEnvironmentConventions {@literal true} only for the reserved
+         *                                   {@value KonfigyrExtension#CENTRAL_REGISTRY_NAME} registry,
+         *                                   enabling its environment variable fallbacks.
+         */
         @Inject
         public TokenExchangeSpec(ObjectFactory factory, ProviderFactory providers, boolean useEnvironmentConventions) {
             this.useEnvironmentConventions = useEnvironmentConventions;
@@ -314,10 +381,24 @@ public class RegistrySpec implements Named {
             }
         }
 
+        /**
+         * Checks whether {@link #clientId}, {@link #subjectToken} and {@link #subjectTokenType} are
+         * all present, either set directly or resolved from their environment variable conventions.
+         *
+         * @return {@literal true} if this grant is fully configured.
+         */
         boolean isConfigured() {
             return clientId.isPresent() && subjectToken.isPresent() && subjectTokenType.isPresent();
         }
 
+        /**
+         * Creates the {@link TokenExchange} described by this specification.
+         * <p>
+         * Callers must have already verified {@link #isConfigured()} returns {@literal true} before
+         * calling this method, since it eagerly resolves every required property and fails otherwise.
+         *
+         * @return the credentials, never {@literal null}.
+         */
         Credentials toCredentials() {
             KonfigyrExtension.assertPropertySet(clientId, "clientId", environmentVariableHint("KONFIGYR_CLIENT_ID"));
             KonfigyrExtension.assertPropertySet(subjectToken, "subjectToken", environmentVariableHint("KONFIGYR_SUBJECT_TOKEN"));

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ResolveServiceDependenciesTask.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ResolveServiceDependenciesTask.java
@@ -30,7 +30,7 @@ import java.util.List;
  * {@link GenerateArtifactMetadataTask}, form the full candidate list
  * {@link CreateServiceReleaseTask} submits to open a service's release. This task is only ever
  * needed when the project has opted into the service-release scenario via
- * {@code konfigyr { service { } } }}, otherwise it does not run.
+ * {@code konfigyr { service { } }}, otherwise it does not run.
  * <p>
  * Every project in the build is identified through {@link #getProjectArtifacts()}, populated at
  * configuration time so this task never needs to access {@link org.gradle.api.Project} objects
@@ -94,7 +94,7 @@ public abstract class ResolveServiceDependenciesTask extends DefaultTask {
     public abstract MapProperty<String, Artifact> getProjectArtifacts();
 
     /**
-     * Whether the project's {@code konfigyr { service { } } }} block has been configured. Only used
+     * Whether the project's {@code konfigyr { service { } }} block has been configured. Only used
      * to gate whether this task should run at all, not otherwise consumed by the task action.
      *
      * @return {@literal true} if the service-release scenario is enabled for this project.

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ServiceReleaseArtifactUploadAction.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ServiceReleaseArtifactUploadAction.java
@@ -17,6 +17,13 @@ import org.jspecify.annotations.NonNull;
  */
 public abstract class ServiceReleaseArtifactUploadAction implements WorkAction<ServiceReleaseArtifactUploadAction.Parameters> {
 
+    /**
+     * The shared {@link ArtifactoryService} this work item uploads through, injected by name rather
+     * than passed via {@link Parameters} since a {@code BuildService} reference cannot be serialized
+     * into work item parameters.
+     *
+     * @return the artifactory service to use, never {@literal null}.
+     */
     @ServiceReference(KonfigyrPlugin.PLUGIN_NAME)
     abstract Property<@NonNull ArtifactoryService> getArtifactoryService();
 
@@ -31,14 +38,38 @@ public abstract class ServiceReleaseArtifactUploadAction implements WorkAction<S
         service.upload(registryName, serviceName, release, artifact);
     }
 
+    /**
+     * Work item parameters for a single {@link #execute()} call, one artifact upload per item,
+     * submitted by {@link CreateServiceReleaseTask}.
+     */
     interface Parameters extends WorkParameters {
 
+        /**
+         * The name of the registry the release was opened against.
+         *
+         * @return the registry name, never {@literal null}.
+         */
         Property<@NonNull String> getRegistryName();
 
+        /**
+         * The name of the service this release belongs to.
+         *
+         * @return the service name, never {@literal null}.
+         */
         Property<@NonNull String> getServiceName();
 
+        /**
+         * The service release this upload contributes to.
+         *
+         * @return the service release, never {@literal null}.
+         */
         Property<@NonNull ServiceRelease> getRelease();
 
+        /**
+         * The artifact metadata payload to upload.
+         *
+         * @return the artifact metadata, never {@literal null}.
+         */
         Property<@NonNull ArtifactMetadata> getArtifact();
 
     }

--- a/konfigyr-plugin-test/src/main/java/com/konfigyr/test/StubFactories.java
+++ b/konfigyr-plugin-test/src/main/java/com/konfigyr/test/StubFactories.java
@@ -25,6 +25,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 /**
  * Factory class for creating stub mappings for testing purposes.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
  */
 @NullMarked
 @CanIgnoreReturnValue


### PR DESCRIPTION
## Summary

Javadoc-only audit of `konfigyr-plugin-core`, `konfigyr-plugin-gradle`, and `konfigyr-plugin-test`, closing documentation gaps left behind by the multi-registry / OAuth2-discovery redesign and the removal of the namespace parameter from the public API. No logic, signatures, annotations, or Gradle lifecycle wiring were touched — comments only.

## Fixed

- **`ArtifactoryClient#isPublished`** — added the missing `@throws HttpResponseException`, which the implementation actually throws for any non-`404` error status.
- **`PublishArtifactMetadataTask`, `CreateServiceReleaseTask`, `ResolveServiceDependenciesTask`** — fixed a brace-balance typo repeated across 4 inline `{@code clientCredentials { } } }}` / `{@code konfigyr { service { } } }}` snippets that rendered with mismatched braces; rebalanced to `{@code clientCredentials { }}` / `{@code konfigyr { service { } }}`.
- **`KonfigyrPlugin`** — class doc described a single `konfigyr` task; rewritten to reflect the per-registry publish/release task-pair architecture.
- **`ArtifactoryService`** — class doc didn't state it's a build-wide singleton keyed by registry name; added.

## Added

Javadoc from scratch for previously undocumented public/package-private members:

- `KonfigyrExtension.ServiceSpec` (`configured` field, `markConfigured()`)
- `RegistrySpec` (`name` field, main constructor) and its nested `ClientCredentialsSpec`/`TokenExchangeSpec` (`useEnvironmentConventions` field — backs a real public getter with zero prior doc — plus constructors, `isConfigured()`, `toCredentials()`)
- `ArtifactoryService` (test-only constructor, `Parameters` interface + `getConfigurations()`, `BackOffExecution` class/constructor/`nextBackOff()`)
- `ServiceReleaseArtifactUploadAction` (`getArtifactoryService()`, `Parameters` interface + all 4 getters)
- `ArtifactMetadataTransform.Parameters` + `getService()`
- `Transport` constructor, `DefaultOAuthClientCredentialsProvider#getNodeValue`
- `ArtifactMetadataParser#resolveDeprecation`/`#resolveDefaultValue`
- `ByteArrayArtifactMetadataResource` / `FileArtifactMetadataResource` — full class + constructor docs (previously none)
- `ResolvedPropertyType.TYPE_RESOLVER`/`STRING_TYPE`, `TypeNameResolver.UNKNOWN_TYPE` (converted from a plain `//` comment) and `#createResolvedType`
- `schema` package: `SchemaGenerationContext.configurationMetadataProperty` (backs a public getter), `DefaultJsonSchemaGenerator` constructor, `PrimitiveSchemaDefinitionProvider` constructor + `createDefinitions`, and `PropertyCandidate` (previously fully undocumented — class + every method)