### PR TITLE
Rewrite README and require an explicit service name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Spring Boot project, no running Konfigyr instance is required.
 2. Make your changes, including tests.
 3. Run `./gradlew check` and ensure everything passes.
 4. Push your branch and open a pull request against `main`.
-5. Fill in the pull request template — in particular, link the relevant issue.
+5. Fill in the pull request template, in particular, link the relevant issue.
 
 Pull requests are reviewed by the maintainers. Small, focused changes are easier to review and merge.
 If you are planning a large change, open an issue first to discuss the approach.

--- a/README.md
+++ b/README.md
@@ -4,283 +4,346 @@
 [![Gradle Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/com.konfigyr.artifactory)](https://plugins.gradle.org/plugin/com.konfigyr.artifactory)
 [![Join the chat at https://gitter.im/konfigyr/konfigyr-plugin](https://badges.gitter.im/konfigyr/konfigyr-plugin.svg)](https://gitter.im/konfigyr/konfigyr-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Build tool plugins for [Konfigyr](https://konfigyr.com). Konfigyr is a platform for centralized configuration management,
-auto-generated documentation, and provenance tracking of Spring Boot configuration properties across your services.
+**Catch a bad Spring Boot property before it ships, not after.** [Konfigyr](https://konfigyr.com) turns the
+configuration metadata your project already generates into a searchable catalog with type-safe validation,
+version history, and provenance for every property. That way, a typo'd key or an invalid value gets caught
+before a change is merged, not after it's paged someone.
 
-## What it does
+This repository contains build plugins that publish your project's Spring Boot configuration metadata
+to Konfigyr as part of your normal build. The Gradle (and, soon, Maven) plugin will scan your project,
+and your project's own dependencies, and send Spring Boot configuration metadata to Konfigyr.
 
-Konfigyr builds a searchable, versioned catalog of your organization's Spring Boot configuration
-properties - complete with types, defaults, and descriptions - by collecting the metadata
-`spring-boot-configuration-processor` already generates for every `@ConfigurationProperties` class.
-That catalog is what powers Konfigyr's validation and documentation, and what lets you trace where a
-property came from and how its defaults changed across versions. This plugin is how your metadata gets
-into that catalog: it runs as part of your normal build, so nobody has to upload anything by hand.
+## Quick Start
 
-Konfigyr calls each jar it processes an **artifact**, identified by its Maven coordinates (`groupId`,
-`artifactId`, `version`) - that includes both your own project's build output and every dependency on
-its classpath that exposes Spring Boot configuration metadata of its own.
+**Requirements:** Java 21+, Gradle 9.5+, and a Spring Boot project using `spring-boot-configuration-processor`.
 
-When you run the plugin, it:
+> **Building a deployable Spring Boot service?** This is almost certainly you. Read on.
+> **Building a library other teams will depend on?** You can skip the `service { }` block entirely. See
+> "Publishing a library" under [Gradle Plugin](#gradle-plugin) below.
 
-1. Scans your compile and runtime classpaths for `spring-configuration-metadata.json` files produced by the
-   [Spring Boot configuration processor](https://docs.spring.io/spring-boot/reference/configuration-metadata/annotation-processor.html).
-2. Generates structured metadata for each artifact found.
-3. Authenticates with Konfigyr using OAuth2 (client credentials or token exchange).
-4. Publishes that metadata to Konfigyr, through one of two scenarios described below.
+1. Apply the plugin:
 
-### Direct artifact publish
+    ```kotlin
+    plugins {
+        id("com.konfigyr.artifactory") version "1.2.0"
+    }
+    ```
 
-Applies to an artifact whose `groupId` has already been **verified** in Konfigyr. Verification happens
-in Konfigyr itself, not through this plugin - a namespace admin proves ownership of the coordinate
-(e.g. `com.acme.*`); this plugin only reacts to whether that's already been done. Once verified, that
-artifact's metadata is published to Konfigyr's shared Artifactory registry, where it becomes reusable by
-every service in your organization that depends on it - published once, regardless of how many services
-use it.
+2. Configure a registry where to publish to:
 
-### Service release
+    ```kotlin
+    konfigyr {
+        registries {
+            konfigyrCentral()
+        }
+    }
+    ```
 
-Applies to everything a service depends on that *isn't* covered by a verified `groupId`: that can be the
-service's own artifact before its `groupId` is verified, or any dependency - internal or third-party -
-your organization doesn't own. Since none of those artifacts can go through direct publish, the service
-reports their metadata itself, on its own behalf, as part of its release. That metadata is captured
-privately, scoped to and visible only from that one service - it is not added to the shared registry.
+    > Credentials are discovered automatically from the environment or via explicit registry configuration.
 
-These two scenarios are independent, not an either/or choice - a project commonly goes through both at
-once (its own verified artifact published directly, its unverified dependencies reported through a
-service release). Konfigyr skips artifacts it already has metadata for, so re-running without changes
-is cheap. Each build tool section below covers the specific configuration and tasks/goals for both
-scenarios.
+3. Name your service. It must match the identifier this service already has in the Konfigyr app; the
+   plugin releases against an existing service, it doesn't create one:
+
+    ```kotlin
+    konfigyr {
+        registries {
+            konfigyrCentral()
+        }
+
+        service {
+            name = "order-service"
+        }
+    }
+    ```
+
+4. Run it, as part of your normal release/deploy pipeline:
+
+    ```shell
+    ./gradlew konfigyr
+    ```
+
+That's it. Konfigyr now has a full picture of every configuration property your service exposes, both
+from your own code and from everything it depends on (see [How it works](#how-it-works) below). Everything
+past this point is about handling more advanced situations: publishing a library your own team owns,
+multiple registries, CI-issued tokens instead of a secret, and multi-module builds.
+
+## How it works
+
+Konfigyr deals with two distinct kinds of things, and the plugin's two publishing mechanisms each target one
+of them:
+
+- An **artifact** is a jar identified by Maven coordinates (`groupId`, `artifactId`, `version`). It's the
+  unit that carries configuration metadata: the `spring-configuration-metadata.json` generated whenever a
+  jar declares `@ConfigurationProperties` classes.
+- A **service** is a namespace-owned, deployable application already registered in Konfigyr. It's the
+  thing your organization actually runs, with a configuration catalog assembled from everything it depends on.
+
+Your project's own build output is always an artifact. If it's also meant to be deployed and run, it's a
+service too, and each of those two identities is handled by a different plugin mechanism:
+
+- **Direct artifact publish** targets the *artifact* side. Any artifact, whether that's a shared library or
+  a service's own jar, can be published directly to Konfigyr's shared registry, but only once its `groupId`
+  is **verified** (a namespace admin has proven ownership of the coordinate, e.g. `com.acme.*`, directly in
+  Konfigyr). Once verified, that artifact's metadata is published once per version and reused by every
+  service in your organization that depends on it.
+- **Releasing** targets the *service* side. Configuring `service { }` opts a project into releasing: every
+  time the service is released (tied to its own deploy/release cadence), the plugin reports its *entire*
+  dependency graph. That means every classpath artifact that exposes configuration metadata, including the
+  service's own jar as just one more entry. Konfigyr resolves as much of that graph as it can from the
+  shared registry, verified or not, and only asks the plugin to upload metadata for whatever it can't
+  otherwise resolve. That upload is captured privately, visible only from that one service, and never added
+  to the shared registry.
+
+In practice, **most projects are services, not libraries**. If you're deploying a Spring Boot application,
+you almost always want `service { }` configured, since it's what builds your service's dependency catalog,
+whether or not your own code defines any configuration properties. Direct publish only matters *on its own*
+for the minority of projects that are themselves libraries other teams verify and depend on.
+
+The two mechanisms aren't a one-time either/or choice, and they don't fight each other. A service's own
+artifact commonly gets both: direct-published once it's verified, and included in every release regardless.
+Once it's verified, later releases automatically stop needing to upload it locally, since Konfigyr can now
+resolve it from the shared registry. Nothing needs to be re-configured for that transition to happen.
 
 ---
 
 ## Gradle Plugin
 
-### Requirements
+<details>
+<summary><strong>Configure a Konfigyr registry</strong></summary>
 
-- Java 21+
-- Gradle 9.5+
-- A Spring Boot project using `spring-boot-configuration-processor`
-- A Konfigyr account with OAuth2 client credentials (a namespace is only needed for the service-release scenario)
+Everything the plugin publishes goes to one or more **registries**, declared in a `registries { }` block.
+Each registry needs a `url` and exactly one OAuth2 grant. Its token endpoint is discovered automatically at
+build time, so you never configure it directly.
 
-### Installation
-
-```kotlin
-// build.gradle.kts
-plugins {
-    id("com.konfigyr.artifactory") version "1.1.0"
-}
-```
-
-```groovy
-// build.gradle
-plugins {
-    id 'com.konfigyr.artifactory' version '1.1.0'
-}
-```
-
-### Two publishing scenarios
-
-The `konfigyr` task shown above drives both scenarios from [What it does](#what-it-does). Here's how they
-map onto Gradle tasks and configuration - which ones actually run for a given project depends only on
-which configuration you've provided (see [Multi-project builds](#multi-project-builds) for an example
-of configuring both at once):
-
-|                      | Direct artifact publish                                        | Service release                                                                    |
-|----------------------|------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-| **Tasks**            | `generateArtifactMetadata` → `publishArtifactMetadata`           | `generateArtifactMetadata` + `resolveServiceDependencies` → `createServiceRelease`    |
-| **Required config**  | `clientCredentials { }` or `tokenExchange { }`                   | Credentials, plus `service { namespace = ... }`                                       |
-| **Runs when**        | Always, once credentials are configured.                         | Only if `service.namespace` is set - otherwise both tasks are skipped.                |
-
-One asymmetry worth knowing about: `publishArtifactMetadata` isn't gated by extra configuration
-the way the service-release tasks are. It always attempts to run once credentials are configured,
-and **fails the build** if this project's own artifact exposes Spring Boot configuration metadata
-but its `groupId` isn't verified in the Artifactory. If a project should only ever go through the
-service-release scenario, disable the direct-publish task explicitly:
+**`konfigyrCentral()`** is the reserved, well-known Konfigyr registry. Its `url` defaults to
+`https://api.konfigyr.com`, and unset credentials fall back to environment variables:
 
 ```kotlin
-tasks.named("publishArtifactMetadata") { enabled = false }
-```
-
-Every property and task in the sections below is labeled with which scenario it belongs to:
-**shared** (used by both), **publish-only**, or **service-only**.
-
-### Configuration
-
-```kotlin                                                                                                                                                                                                                                                                 
 konfigyr {
-    clientCredentials {
-        clientId = "acme-corp-client-id"
-        clientSecret = "acme-corp-client-secret"
+    registries {
+        konfigyrCentral() // KONFIGYR_CLIENT_ID / KONFIGYR_CLIENT_SECRET / KONFIGYR_SUBJECT_TOKEN
+    }
+}
+```
+
+To set credentials explicitly instead (never hardcode a real secret in a committed build file):
+
+```kotlin
+konfigyr {
+    registries {
+        konfigyrCentral {
+            clientCredentials {
+                clientId = "acme-corp-client-id"
+                clientSecret = "acme-corp-client-secret"
+            }
+        }
+    }
+}
+```
+
+If your CI issues short-lived identity tokens (e.g. an OIDC token) instead of a long-lived secret, use
+`tokenExchange { }` instead. This is the only grant with no environment-variable default for its token type,
+since there's no sensible one to assume:
+
+```kotlin
+konfigyr {
+    registries {
+        konfigyrCentral {
+            tokenExchange {
+                subjectTokenType = "urn:ietf:params:oauth:token-type:jwt"
+                // clientId / subjectToken still resolve from KONFIGYR_CLIENT_ID / KONFIGYR_SUBJECT_TOKEN
+            }
+        }
+    }
+}
+```
+
+**A custom, self-hosted registry** works the same way if you're running your own Konfigyr instance. Give it
+a name of your choosing, and set every value explicitly, since no environment-variable fallback applies:
+
+```kotlin
+konfigyr {
+    registries {
+        registry("staging") {
+            url = uri("https://staging.konfigyr.internal")
+
+            clientCredentials {
+                clientId = "acme-corp-client-id"
+                clientSecret = "acme-corp-client-secret"
+            }
+        }
+    }
+}
+```
+
+You can declare as many registries as you need. Every one gets published to independently. If both
+`clientCredentials { }` and `tokenExchange { }` are configured on the same registry, `tokenExchange` wins.
+
+</details>
+
+<details>
+<summary><strong>Releasing a service</strong></summary>
+
+If you're deploying a Spring Boot application (as opposed to publishing a library), add a `service { }`
+block, giving it the same `name` your service is already registered under in Konfigyr. That's what opts a
+project into releasing. Every release then reports the project's complete dependency graph to Konfigyr, so
+its catalog stays complete and current for that service, whether or not any given dependency is itself
+verified:
+
+```kotlin
+konfigyr {
+    registries {
+        konfigyrCentral()
     }
 
-    // Optional - only needed if this project should also go through the service-release scenario
     service {
-        namespace = "acme-corp"
+        name = "order-service"
     }
 }
 ```
 
-The plugin provides the `konfigyr` task that would scan the application classpath for `spring-configuration-metadata.json` files
-and upload them to the specified Konfigyr server instance.
+`name` **must match the service's identifier (URL slug) in the Konfigyr app exactly**. It's how a release
+is linked to the right service, not just a descriptive label. It will not match your Gradle module name in
+most real projects, so don't rely on any default; set it explicitly to the identifier Konfigyr already has.
 
-#### Credentials
+</details>
 
-*Shared* - required either way, both scenarios need it to authenticate with Konfigyr. Choose
-exactly one OAuth2 grant type. `clientCredentials { }` is the simplest option, authenticating
-directly with a long-lived client secret:
+<details>
+<summary><strong>Publishing a library</strong></summary>
+
+If your project isn't a deployable service but a library other teams depend on, skip `service { }`
+entirely. There's no release, no dependency graph to report. Configure your registries and credentials as
+above, and once your `groupId` is verified in Konfigyr, the plugin's direct-publish task does the rest:
+publishing your library's own configuration metadata, once per version, to the shared registry where every
+consuming service can resolve it automatically, without reporting it themselves:
 
 ```kotlin
 konfigyr {
-    clientCredentials {
-        clientId = "acme-corp-client-id"         // or KONFIGYR_CLIENT_ID env var
-        clientSecret = "acme-corp-client-secret" // or KONFIGYR_CLIENT_SECRET env var
+    registries {
+        konfigyrCentral()
     }
 }
 ```
 
-`tokenExchange { }` is the alternative for CI environments that issue short-lived identity tokens (for example an
-OIDC token from your CI provider) instead of a long-lived secret:
+Verification itself happens in Konfigyr, not in this plugin. A namespace admin proves ownership of your
+`groupId` (e.g. `com.acme.*`) before anything can be published under it. Until that's done, the publish task
+fails rather than silently skipping, see the FAQ below.
+
+</details>
+
+<details>
+<summary><strong>Tasks</strong></summary>
+
+The plugin registers one publish/release task pair **per declared registry**, plus a shared `konfigyr`
+umbrella task. For a registry named `staging`, the publish task is `publishArtifactMetadataToStaging`; for
+the reserved `konfigyrCentral` registry, it's `publishArtifactMetadataToKonfigyrCentral`, and so on.
+
+| Task | Scenario | Runs when |
+|---|---|---|
+| `konfigyr` | Both | Always. Depends on every registry's publish/release tasks below. |
+| `generateArtifactMetadata` | Shared | Always. Scans this project's own built jar; feeds both scenarios. Cacheable. |
+| `publishArtifactMetadataTo<Registry>` | Direct publish | Whenever `<Registry>` has a `url` and a grant configured. |
+| `resolveServiceDependencies` | Service release | Only if `service { }` is configured. Cacheable. |
+| `createServiceReleaseTo<Registry>` | Service release | Only if `service { }` **and** `<Registry>` are both configured. |
+
+For most projects (deployable services), `createServiceReleaseTo<Registry>` is where the real value is. It's
+what builds the service's dependency catalog. `publishArtifactMetadataTo<Registry>` only does something when
+the project's own jar exposes configuration metadata; otherwise it's a no-op.
+
+You can run any task individually, e.g. `./gradlew generateArtifactMetadata` to scan and write metadata
+locally with no network calls. Generated files live under `build/konfigyr/` and are fully cacheable.
+Re-running without classpath changes is instant.
+
+</details>
+
+<details>
+<summary><strong>Multi-project builds</strong></summary>
+
+A registry's connection is shared build-wide, not per-project. Apply the plugin selectively and configure
+the shared registries once, typically on the root project or via `subprojects { }`:
 
 ```kotlin
-konfigyr {
-    tokenExchange {
-        clientId = "acme-corp-client-id"                         // or KONFIGYR_CLIENT_ID env var
-        subjectToken = "..."                                     // or KONFIGYR_SUBJECT_TOKEN env var
-        subjectTokenType = "urn:ietf:params:oauth:token-type:jwt" // no default, must be set explicitly
-    }
-}
-```
-
-#### Available configuration properties
-
-| Property                         | Scenario        | Type     | Default                                | Description                                                                                        |
-|-----------------------------------|-----------------|----------|-----------------------------------------|-----------------------------------------------------------------------------------------------------|
-| `host`                           | Shared          | `String` | `https://api.konfigyr.com`              | Base URL of the Konfigyr API. Override when self-hosting.                                           |
-| `tokenUri`                       | Shared          | `String` | `https://id.konfigyr.com/oauth/token`   | OAuth2 token endpoint. Override when self-hosting.                                                  |
-| `clientCredentials.clientId`     | Shared          | `String` | `KONFIGYR_CLIENT_ID` env var            | OAuth2 client ID for authentication.                                                                 |
-| `clientCredentials.clientSecret` | Shared          | `String` | `KONFIGYR_CLIENT_SECRET` env var        | OAuth2 client secret for authentication.                                                             |
-| `tokenExchange.clientId`         | Shared          | `String` | `KONFIGYR_CLIENT_ID` env var            | OAuth2 client ID for authentication.                                                                 |
-| `tokenExchange.subjectToken`     | Shared          | `String` | `KONFIGYR_SUBJECT_TOKEN` env var        | The token being exchanged for a Konfigyr access token.                                              |
-| `tokenExchange.subjectTokenType` | Shared          | `String` | *(required, no default)*                | RFC 8693 token type identifier for the subject token, e.g. `urn:ietf:params:oauth:token-type:jwt`.  |
-| `service.namespace`              | Service-only    | `String` | `KONFIGYR_NAMESPACE` env var            | Konfigyr namespace your service belongs to. Setting this is what turns on the service-release scenario. |
-| `service.name`                   | Service-only    | `String` | Project name                            | Service name used to group metadata in Konfigyr. Defaults to the Gradle project name.               |
-| `publish.pollTimeout`            | Publish-only    | `Long`   | `600000` (10 minutes)                   | How long to wait for a direct-publish release to be confirmed, in milliseconds.                     |
-| `publish.pollInterval`           | Publish-only    | `Long`   | `1000` (1 second)                       | Initial polling interval in milliseconds. Uses exponential backoff (×1.75 per attempt).             |
-
-`service { }` and `publish { }` are always available with the defaults above even if you never write the block -
-configuring them is only needed to override those defaults, or, for `service { }`, to turn on the service-release
-scenario by setting `namespace`. A pure library with no `service.namespace` configured simply skips the
-service-release tasks.
-
-#### Authentication via environment variables
-
-Credentials should never be hardcoded in build files. The plugin reads them from environment variables automatically
-(this example uses the `client_credentials` grant; `KONFIGYR_SUBJECT_TOKEN` is the equivalent for `tokenExchange { }`):
-
-```shell
-export KONFIGYR_NAMESPACE=acme-corp
-export KONFIGYR_CLIENT_ID=acme-corp-client-id
-export KONFIGYR_CLIENT_SECRET=acme-corp-client-secret
-```
-
-Note that even when relying purely on environment variables, the build script must still call `clientCredentials { }`
-(an empty body is fine) to select that grant type - see [Credentials](#credentials) above.
-
-### Running
-
-```shell
-./gradlew konfigyr
-```
-
-This runs the direct-publish scenario (`generateArtifactMetadata` then `publishArtifactMetadata`) always, and the
-service-release scenario (`resolveServiceDependencies` then `createServiceRelease`) only if `service.namespace` is
-set. You can also run each task individually:
-
-```shell
-# Scan and write metadata locally — no network calls
-./gradlew generateArtifactMetadata
-
-# Generate and then publish this project's own metadata directly to Konfigyr
-./gradlew publishArtifactMetadata
-
-# Resolve dependency metadata and open a service release (requires service.namespace to be set)
-./gradlew createServiceRelease
-```
-
-Generated files are written under `build/konfigyr/` and are fully cacheable, re-running without classpath changes is
-instant.
-
-### Tasks
-
-| Task                          | Scenario       | Group      | Description                                                                                          |
-|--------------------------------|----------------|------------|--------------------------------------------------------------------------------------------------------|
-| `konfigyr`                    | Both           | `konfigyr` | Umbrella task; runs `publishArtifactMetadata` and `createServiceRelease` (which pulls in the other two as needed). |
-| `generateArtifactMetadata`    | Shared         | `konfigyr` | Scans this project's own built jar and writes its metadata to `build/konfigyr/metadata.json`, if it exposes any. Feeds both scenarios. Cacheable. |
-| `publishArtifactMetadata`     | Publish-only   | `konfigyr` | Publishes this project's own generated metadata directly to Konfigyr. Always runs (not cached) - see the note above about disabling it if unwanted. |
-| `resolveServiceDependencies`  | Service-only   | `konfigyr` | Scans this service's dependencies for configuration metadata. Only runs if `service.namespace` is set. Cacheable. |
-| `createServiceRelease`        | Service-only   | `konfigyr` | Opens a service release and uploads required dependency (and own) metadata. Only runs if `service.namespace` is set. Always runs (not cached). |
-
-### Multi-project builds
-
-Apply the plugin selectively and share the common configuration at the root:
-
-```kotlin                                                                                                                                                                                                                                                                 
-// root build.gradle.kts                                                                                                                                                                                                                              
-
+// root build.gradle.kts
 plugins {
-    id("com.konfigyr.artifactory") version "1.1.0" apply false
+    id("com.konfigyr.artifactory") version "1.2.0" apply false
 }
 
 subprojects {
     apply(plugin = "com.konfigyr.artifactory")
 
     konfigyr {
-        clientCredentials {
-            clientId = "acme-corp-client-id"
-            clientSecret = "acme-corp-client-secret"
-        }
-
-        // Optional - only for subprojects that should also go through the service-release scenario
-        service {
-            namespace = "acme-corp"
+        registries {
+            konfigyrCentral()
         }
     }
 }
 ```
 
-The connection to Konfigyr is a single build-wide service, so every subproject configuring the plugin must resolve
-to identical `host`/`tokenUri`/credentials - as they do above, since `subprojects { }` applies the same block to all
-of them. If subprojects end up with different connection settings, the build fails rather than picking one silently.
-Configuring the root project's own `konfigyr { }` block directly (instead of via `subprojects { }`) is what lets you
-set connection details in exactly one place.
+If subprojects end up declaring different connection settings for the same registry name, the build fails
+rather than silently picking one. Configuring the root project's own `konfigyr { }` block directly (instead
+of only via `subprojects { }`) is what lets you pin the connection in exactly one place.
 
-To publish metadata for all subprojects in one command:
-
-```shell
-./gradlew konfigyr
-```
-
-### Self-hosted Konfigyr instances                                                                                                                                                                                                                                                  
-
-Override `host` and `tokenUri` when running your own instance:                                                                                                                                                                                                            
+`service { }` is *not* part of that shared block. It's configured per-project, only where it applies. In a
+typical multi-module build, only the module that's actually deployed configures a `service { }`; everything
+else is a library dependency and needs nothing beyond the shared registry:
 
 ```kotlin
+// api/build.gradle.kts (the module that's actually deployed)
 konfigyr {
-   host     = "https://api.konfigyr.internal"
-   tokenUri = "https://id.konfigyr.internal/oauth/token"
+    service {
+        name = "order-service"
+    }
 }
+
+// common/build.gradle.kts (a library module the service depends on, nothing to add here)
 ```
 
----                                                                                                                                                                                                                                                                       
-                                                                                                                                                                                                                                                                          
-## Maven Plugin
+A build made up entirely of libraries, with no deployable service anywhere, is equally valid. In that
+case, no subproject configures `service { }` at all.
 
-> **Coming soon.** The Maven plugin is not yet implemented. Contributions are welcome, feel free to open a pull
-request or follow [the issue tracker](https://github.com/konfigyr/konfigyr-plugin/issues) for updates.
+To publish metadata for every subproject in one command, run `./gradlew konfigyr` from the root.
 
-Once available, it will provide equivalent functionality for Maven projects via a dedicated goal.
+</details>
+
+<details>
+<summary><strong>FAQ / Troubleshooting</strong></summary>
+
+**My build failed with an HTTP error from `publishArtifactMetadataTo...`. Why?**
+That task runs whenever its registry is configured, independently of whether your `groupId` happens to be
+verified yet. Verification is a Konfigyr-side, not a plugin-side, check. If your project's own artifact
+exposes configuration metadata but its `groupId` isn't verified for that registry, the direct-publish call
+is rejected and the build fails. If a project should only ever go through the service-release scenario,
+disable the task explicitly:
+
+```kotlin
+tasks.named("publishArtifactMetadataToKonfigyrCentral") { enabled = false }
+```
+
+**Do I need to create the service in Konfigyr before I can release to it?**
+Yes, you need to have an existing service to perform releases. Releases are linked to an existing service by
+its `name`/identifier. The plugin does not create services on your behalf; it only releases against one
+that's already registered in the Konfigyr app.
+
+</details>
 
 ---
+
+## Maven Plugin
+
+> **Coming soon.** The Maven plugin is not yet implemented. Contributions are welcome, feel free to open a
+> pull request or follow [the issue tracker](https://github.com/konfigyr/konfigyr-plugin/issues) for updates.
+
+Once available, it will provide equivalent functionality for Maven projects via a dedicated goal, using the
+same registry and scenario model described above.
+
+---
+
+## Getting help & contributing
+
+- **Questions / discussion:** the [#konfigyr-plugin room on Gitter](https://gitter.im/konfigyr/konfigyr-plugin), see [SUPPORT.md](SUPPORT.md).
+- **Bugs / feature requests:** [GitHub Issues](https://github.com/konfigyr/konfigyr-plugin/issues).
+- **Contributing a change:** see [CONTRIBUTING.md](CONTRIBUTING.md) for the development setup, project layout, and PR process.
+- This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/ArtifactoryClient.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/ArtifactoryClient.java
@@ -13,18 +13,23 @@ import java.util.Collection;
  * network errors; a single instance is typically shared across an entire build invocation spanning
  * multiple projects or modules, reusing one authenticated connection rather than one per project.
  * <p>
- * This interface supports two distinct publishing workflows. Which one applies to a given artifact
- * depends on whether the publishing namespace's {@code groupId} has been verified. Neither workflow
- * takes a namespace as an argument: the namespace is always resolved server-side from the
+ * This interface supports two distinct publishing workflows, addressing two different concerns. A
+ * service release reports a service's entire dependency footprint every time that service is
+ * released, whether or not any given dependency's {@code groupId} happens to be verified. Direct
+ * publish targets a single artifact, and requires that artifact's {@code groupId} to already be
+ * verified. A project's own artifact is commonly involved in both at once: reported as one of many
+ * candidates in its service's release, and, once verified, published directly on its own. Neither
+ * workflow takes a namespace as an argument: the namespace is always resolved server-side from the
  * authenticated access token's claims, never asserted by the caller.
  *
  * <h2>Publishing first-party metadata via a Service Release</h2>
  * <p>
- * Used for artifacts not covered by a verified {@code groupId}. Metadata published this way is
- * scoped to a single namespace and service, it is not added to the shared Artifactory registry.
- * Because a single client instance may be shared across many services (e.g. the modules of a
- * multi-module build), the target {@code service} is supplied as an argument to each call below
- * rather than fixed once for the client's lifetime.
+ * Reports every artifact discovered on a service's classpath that exposes configuration metadata,
+ * whether or not its {@code groupId} is verified. Metadata published this way is scoped to a single
+ * namespace and service, it is not added to the shared Artifactory registry. Because a single client
+ * instance may be shared across many services (e.g. the modules of a multi-module build), the target
+ * {@code service} is supplied as an argument to each call below rather than fixed once for the
+ * client's lifetime.
  * <ol>
  *   <li>Call {@link #release(String, Collection)} with every artifact discovered on the
  *       classpath that exposes Spring Boot configuration metadata, each paired with a locally

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/CreateServiceReleaseTask.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/CreateServiceReleaseTask.java
@@ -104,13 +104,12 @@ public abstract class CreateServiceReleaseTask extends DefaultTask {
     public abstract Property<@NonNull String> getRegistryName();
 
     /**
-     * The Konfigyr service name. Defaults to the Gradle {@link org.gradle.api.Project}
-     * name if not specified.
+     * The Konfigyr service name. Must match the identifier this service already has in the Konfigyr app;
+     * there is no default, it must always be set explicitly via {@code konfigyr { service { name = ... } }}.
      *
      * @return the service name, never {@literal null}.
      */
     @Input
-    @Optional
     public abstract Property<@NonNull String> getServiceName();
 
     /**

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrExtension.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrExtension.java
@@ -7,6 +7,7 @@ import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -30,7 +31,7 @@ import java.time.Duration;
  *     // Optional: only needed for the service-release scenario - calling this block at all is what
  *     // opts a project into it, regardless of what's configured inside
  *     service {
- *         name = "order-service" // defaults to project.name
+ *         name = "order-service" // must match this service's identifier in the Konfigyr app
  *     }
  *
  *     // Optional: direct-publish polling behavior
@@ -117,7 +118,7 @@ public class KonfigyrExtension {
         registries = factory.domainObjectContainer(RegistrySpec.class,
                 name -> factory.newInstance(RegistrySpec.class, name, objects, providers, CENTRAL_REGISTRY_NAME.equals(name)));
 
-        service = new ServiceSpec(factory, project.getName());
+        service = new ServiceSpec(factory);
         publish = new PublishSpec(factory);
     }
 
@@ -201,6 +202,19 @@ public class KonfigyrExtension {
         action.execute(publish);
     }
 
+    /**
+     * Returns the name of the service this project releases against. Defined by the
+     * {@link #service(Action)} block, or the {@code konfigyr { service { name = ... } }} block.
+     *
+     * @return the configured service name provider, never {@literal null}.
+     */
+    Provider<String> resolveServiceName() {
+        return providers.provider(() -> {
+            assertPropertySet(service.getName(), "service.name", null);
+            return service.getName().get();
+        });
+    }
+
     static void assertPropertySet(Property<?> property, String name, @Nullable String env) {
         if (!property.isPresent()) {
             final String suffix = env != null ? " or via the '" + env + "' environment variable" : "";
@@ -227,8 +241,8 @@ public class KonfigyrExtension {
     public static final class ServiceSpec {
 
         /**
-         * Specify the Konfigyr service name for which this plugin would upload the configuration
-         * metadata, defaults to the current project name.
+         * The Konfigyr service this project releases against. Must match the identifier this service
+         * already has in the Konfigyr app exactly; there is no default, it must always be set explicitly.
          */
         private final Property<String> name;
 
@@ -237,8 +251,8 @@ public class KonfigyrExtension {
          */
         private boolean configured;
 
-        ServiceSpec(ObjectFactory factory, String projectName) {
-            name = factory.property(String.class).convention(projectName);
+        ServiceSpec(ObjectFactory factory) {
+            name = factory.property(String.class);
         }
 
         /**

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrPlugin.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrPlugin.java
@@ -277,7 +277,7 @@ public class KonfigyrPlugin implements Plugin<@NonNull Project> {
             task.getDependencyManifest().set(project.getLayout().getBuildDirectory().file("konfigyr/dependency-manifest.txt"));
             task.getDependencyDirectory().set(project.getLayout().getBuildDirectory().dir("konfigyr/dependencies"));
             task.getServiceConfigured().set(project.provider(() -> extension.getService().isConfigured()));
-            task.getServiceName().set(extension.getService().getName());
+            task.getServiceName().set(extension.resolveServiceName());
 
             task.getService().set(service);
             task.usesService(service);
@@ -309,7 +309,7 @@ public class KonfigyrPlugin implements Plugin<@NonNull Project> {
             task.getDependencyManifest().set(resolveDependenciesTask.flatMap(ResolveServiceDependenciesTask::getDependencyManifest));
             task.getDependencyDirectory().set(resolveDependenciesTask.flatMap(ResolveServiceDependenciesTask::getDependencyDirectory));
             task.getReleaseConfigured().set(project.provider(() -> extension.getService().isConfigured() && registry.isConfigured()));
-            task.getServiceName().set(extension.getService().getName());
+            task.getServiceName().set(extension.resolveServiceName());
             task.getRegistryName().set(registryName);
 
             task.getService().set(service);

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ResolveServiceDependenciesTask.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ResolveServiceDependenciesTask.java
@@ -103,13 +103,12 @@ public abstract class ResolveServiceDependenciesTask extends DefaultTask {
     public abstract Property<Boolean> getServiceConfigured();
 
     /**
-     * The name of the Konfigyr service. Defaults to the Gradle {@link org.gradle.api.Project}
-     * name if not specified.
+     * The Konfigyr service name. Must match the identifier this service already has in the Konfigyr app;
+     * there is no default, it must always be set explicitly via {@code konfigyr { service { name = ... } }}.
      *
      * @return the service name, never {@literal null}.
      */
     @Input
-    @Optional
     public abstract Property<String> getServiceName();
 
     /**

--- a/konfigyr-plugin-gradle/src/test/java/com/konfigyr/gradle/KonfigyrExtensionTest.java
+++ b/konfigyr-plugin-gradle/src/test/java/com/konfigyr/gradle/KonfigyrExtensionTest.java
@@ -79,4 +79,17 @@ class KonfigyrExtensionTest {
         assertThat(extension.getRegistries().getByName("staging")).isNotNull();
     }
 
+    @Test
+    @DisplayName("service { } should be validated to make sure name is specified")
+    void validatesServiceName() {
+        assertThatExceptionOfType(GradleException.class)
+                .isThrownBy(extension.resolveServiceName()::get)
+                .withMessageContaining("Konfigyr plugin requires 'service.name' to be set");
+
+        extension.service(service -> service.getName().set("my-service"));
+
+        assertThat(extension.resolveServiceName().get())
+                .isEqualTo("my-service");
+    }
+
 }

--- a/konfigyr-plugin-gradle/src/test/java/com/konfigyr/gradle/KonfigyrPluginMultiProjectTest.java
+++ b/konfigyr-plugin-gradle/src/test/java/com/konfigyr/gradle/KonfigyrPluginMultiProjectTest.java
@@ -74,7 +74,7 @@ class KonfigyrPluginMultiProjectTest extends AbstractKonfigyrPluginTest {
                 .putPOJO("errors", Collections.emptyList())
                 .toPrettyString();
 
-        // one stub answers all four projects (core/customers/inventory/orders), so the body matcher
+        // one stub answers all three projects (customers/inventory/orders), so the body matcher
         // only pins the groupId shared by all of them plus a non-blank checksum, not a specific artifactId
         wiremock.stubFor(
                 post(urlPathTemplate("/releases/{service}"))
@@ -149,6 +149,12 @@ class KonfigyrPluginMultiProjectTest extends AbstractKonfigyrPluginTest {
                 .typeName(DataSize.class);
         PropertyDescriptorAssert.assertThat(findProperty(metadata, "acme.core.ssl"))
                 .typeName(Resource.class);
+
+        // verify that releases are created for all 3 services and that the service names
+        // are taken from the configuration. The `customer` module uses a custom `customer-service` name
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo("/releases/customer-service")));
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo("/releases/inventory")));
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo("/releases/orders")));
     }
 
 }

--- a/konfigyr-plugin-gradle/src/test/java/com/konfigyr/gradle/KonfigyrPluginRegistryResolutionTest.java
+++ b/konfigyr-plugin-gradle/src/test/java/com/konfigyr/gradle/KonfigyrPluginRegistryResolutionTest.java
@@ -149,7 +149,9 @@ class KonfigyrPluginRegistryResolutionTest extends AbstractWiremockTest {
                             }
                         }
                     }
-                    service { }
+                    service {
+                      name = project.name
+                    }
                 }
                 """.formatted(url, clientId, clientSecret);
     }

--- a/konfigyr-plugin-gradle/src/test/resources/com.acme.multiproject/multiproject/build.gradle
+++ b/konfigyr-plugin-gradle/src/test/resources/com.acme.multiproject/multiproject/build.gradle
@@ -43,7 +43,5 @@ subprojects {
             pollTimeout = 3000
             pollInterval = 200
         }
-        service {
-        }
     }
 }

--- a/konfigyr-plugin-gradle/src/test/resources/com.acme.multiproject/multiproject/customers/build.gradle
+++ b/konfigyr-plugin-gradle/src/test/resources/com.acme.multiproject/multiproject/customers/build.gradle
@@ -8,3 +8,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-rest:4.0.3'
     implementation 'org.springframework.boot:spring-boot-starter-mail:4.0.3'
 }
+
+konfigyr {
+    service {
+        name = 'customer-service'
+    }
+}

--- a/konfigyr-plugin-gradle/src/test/resources/com.acme.multiproject/multiproject/inventory/build.gradle
+++ b/konfigyr-plugin-gradle/src/test/resources/com.acme.multiproject/multiproject/inventory/build.gradle
@@ -5,3 +5,9 @@ plugins {
 dependencies {
     implementation project(':customers')
 }
+
+konfigyr {
+    service {
+        name = 'inventory'
+    }
+}

--- a/konfigyr-plugin-gradle/src/test/resources/com.acme.multiproject/multiproject/orders/build.gradle
+++ b/konfigyr-plugin-gradle/src/test/resources/com.acme.multiproject/multiproject/orders/build.gradle
@@ -9,3 +9,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa:4.0.3'
     implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-resource-server:4.0.3'
 }
+
+konfigyr {
+    service {
+        name = project.name
+    }
+}


### PR DESCRIPTION

## Summary

Rewrites the README to match the current plugin, and closes a real behavior gap around `service.name` that the README rewrite surfaced along the way.

### README rewrite

The existing `README.md` documented the pre-multi-registry API: a flat `host`/`tokenUri` DSL, top-level `clientCredentials { }`, and `service.namespace` as a config property. None of that exists anymore since #49's discovery-based OAuth2 / multi-registry redesign, so copy-pasting anything past "Installation" in the old README would fail against the current plugin.

The new README:
- Leads with the `service { }` path, since most projects are deployable services, not libraries, and get no value from direct-publish alone if they have no configuration properties of their own.
- Explains the two publishing mechanisms (direct artifact publish vs. releasing a service) as two answers to two different questions ("is this artifact verified?" vs. "what does this service depend on right now?"), not an either/or choice.
- Moves deep reference material (registries, tasks, multi-project builds, FAQ) into collapsible `<details>` sections so the top of the page stays a fast, working quick start.
- Documents that `service.name` must match an existing service's identifier in the Konfigyr app, the plugin releases against a service, it doesn't create one.
- Links out to `CONTRIBUTING.md`, `SUPPORT.md`, and `CODE_OF_CONDUCT.md`, none of which the old README referenced.

### `service.name` no longer defaults to the project name

`KonfigyrExtension.ServiceSpec.name` previously defaulted to the Gradle project name via `.convention(projectName)`. That's a bad default: `name` identifies a service already registered in Konfigyr, not an arbitrary label, and it commonly won't match whatever the bootable Gradle module happens to be called. The default is removed; `name` must now be set explicitly.

Validation is added via a lazy `Provider` rather than an eager read. Mirroring the existing pattern for `url/clientId/clientSecret`. The check only runs when Gradle actually needs the value (task input snapshotting, right before execution), not at plugin `apply()` time, before the build script has even configured the block, and without baking an eager read into the configuration cache.

### Javadoc fix

`ArtifactoryClient`'s class-level doc framed direct publish and service release as an either/or choice decided by an artifact's verification status. That contradicted its own `release()` method doc (and every task doc downstream), which correctly describes a release as reporting a service's entire dependency graph regardless of verification. Reworded to reflect that a service release always covers the full graph, with direct publish being the separate, verification-gated path for a single artifact.
