### PR TITLE
Enable Gradle build/configuration cache, and parallel execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,12 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-read-only: true
 
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v6
 
       - name: Build
-        run: ./gradlew --no-daemon --no-parallel --continue build
+        run: ./gradlew --no-daemon --continue build
 
       - name: Test Reports
         uses: mikepenz/action-junit-report@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,7 @@ jobs:
           cache-read-only: true
 
       - name: Build
-        run: ./gradlew --no-daemon --no-parallel --continue check
+        run: ./gradlew --no-daemon --continue check
 
       - name: Test Reports
         uses: mikepenz/action-junit-report@v6

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
     alias(libs.plugins.gradle.compatibility) apply false
 }
 
+repositories {
+    mavenCentral()
+}
+
 subprojects {
     apply(plugin = "idea")
     apply(plugin = "jacoco")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.parallel=true


### PR DESCRIPTION
Enable `org.gradle.caching`, `org.gradle.configuration-cache`, and `org.gradle.parallel` in `gradle.properties` to speed up local and CI builds.

Also drops `--no-parallel` from CI/PR workflows and enables cache writes on the main-branch build, since both were silently negating the new Gradle settings.
