### PR TITLE
Add regex, currency, year, and year-month schema formats

### DIFF
--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/schema/PrimitiveSchemaDefinitionProvider.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/schema/PrimitiveSchemaDefinitionProvider.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.time.*;
 import java.util.*;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
@@ -123,9 +124,13 @@ final class PrimitiveSchemaDefinitionProvider<T extends JsonSchema, B extends Js
         /* Custom string type formats */
         definitions.add(PrimitiveSchemaDefinition.string(loader, UUID.class, "uuid"));
         definitions.add(PrimitiveSchemaDefinition.string(loader, Charset.class, "charset"));
+        definitions.add(PrimitiveSchemaDefinition.string(loader, Pattern.class, "regex"));
         definitions.add(PrimitiveSchemaDefinition.string(loader, ZoneId.class, "time-zone"));
         definitions.add(PrimitiveSchemaDefinition.string(loader, TimeZone.class, "time-zone"));
+        definitions.add(PrimitiveSchemaDefinition.string(loader, YearMonth.class, "year-month"));
+        definitions.add(PrimitiveSchemaDefinition.string(loader, Year.class, "year"));
         definitions.add(PrimitiveSchemaDefinition.string(loader, Locale.class, "language"));
+        definitions.add(PrimitiveSchemaDefinition.string(loader, Currency.class, "currency"));
         definitions.add(PrimitiveSchemaDefinition.string(loader, Inet4Address.class, "ipv4"));
         definitions.add(PrimitiveSchemaDefinition.string(loader, Inet6Address.class, "ipv6"));
 
@@ -133,23 +138,22 @@ final class PrimitiveSchemaDefinitionProvider<T extends JsonSchema, B extends Js
                 PrimitiveSchemaDefinition.of(loader, javaType, JsonSchemaType.BOOLEAN)
         ));
 
+        Stream.of(Short.class, short.class).forEach(javaType -> definitions.add(
+                PrimitiveSchemaDefinition.integer(loader, javaType, "int16")
+        ));
         Stream.of(Integer.class, int.class).forEach(javaType -> definitions.add(
                 PrimitiveSchemaDefinition.integer(loader, javaType, "int32")
         ));
         Stream.of(Long.class, long.class).forEach(javaType -> definitions.add(
                 PrimitiveSchemaDefinition.integer(loader, javaType, "int64")
         ));
-        Stream.of(BigInteger.class, Short.class, short.class).forEach(javaType -> definitions.add(
-                PrimitiveSchemaDefinition.integer(loader, javaType, null)
-        ));
-
         Stream.of(Double.class, double.class).forEach(javaType -> definitions.add(
                 PrimitiveSchemaDefinition.number(loader, javaType, "double")
         ));
         Stream.of(Float.class, float.class).forEach(javaType -> definitions.add(
                 PrimitiveSchemaDefinition.number(loader, javaType, "float")
         ));
-        Stream.of(BigDecimal.class, Number.class).forEach(javaType -> definitions.add(
+        Stream.of(BigInteger.class, BigDecimal.class, Number.class).forEach(javaType -> definitions.add(
                 PrimitiveSchemaDefinition.number(loader, javaType, null)
         ));
         return Collections.unmodifiableSet(definitions);

--- a/konfigyr-plugin-core/src/test/java/com/konfigyr/SanityTest.java
+++ b/konfigyr-plugin-core/src/test/java/com/konfigyr/SanityTest.java
@@ -53,7 +53,7 @@ class SanityTest {
                                                         .property("key", StringSchema.builder().format("uri").build())
                                                         .property("size", StringSchema.builder().format("data-size").build())
                                                         .property("ttl", StringSchema.builder().format("duration").build())
-                                                        .property("maxPoolSize", IntegerSchema.instance())
+                                                        .property("maxPoolSize", NumberSchema.instance())
                                                         .property("missing", ObjectSchema.instance())
                                                         .build()
                                         )

--- a/konfigyr-plugin-core/src/test/java/com/konfigyr/schema/JsonSchemaGeneratorTest.java
+++ b/konfigyr-plugin-core/src/test/java/com/konfigyr/schema/JsonSchemaGeneratorTest.java
@@ -31,6 +31,8 @@ import java.net.InetAddress;
 import java.nio.charset.Charset;
 import java.time.*;
 import java.util.*;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThatObject;
@@ -126,18 +128,21 @@ class JsonSchemaGeneratorTest {
                 .isEqualTo(BooleanSchema.instance());
     }
 
-    @ValueSource(classes = { BigInteger.class, Short.class, short.class })
-    @ParameterizedTest(name = "should generate integer schema for \"{0}\"")
-    @DisplayName("should generate simple integer schema without formats")
-    void generatesIntegerSchema(Class<?> type) {
+    @ValueSource(classes = { Short.class, short.class })
+    @ParameterizedTest(name = "should generate integer schema for \"{0}\" with int16 format")
+    @DisplayName("should generate int16 format based integer schema")
+    void generatesShortIntegerSchema(Class<?> type) {
         assertThatSchema(type)
-                .isEqualTo(IntegerSchema.instance());
+                .returns(JsonSchemaType.INTEGER, JsonSchema::type)
+                .isInstanceOf(IntegerSchema.class)
+                .asInstanceOf(InstanceOfAssertFactories.type(IntegerSchema.class))
+                .returns("int16", IntegerSchema::format);
     }
 
     @ValueSource(classes = { Integer.class, int.class })
     @ParameterizedTest(name = "should generate integer schema for \"{0}\" with int32 format")
     @DisplayName("should generate int32 format based integer schema")
-    void generatesShortIntegerSchema(Class<?> type) {
+    void generatesRegularIntegerSchema(Class<?> type) {
         assertThatSchema(type)
                 .returns(JsonSchemaType.INTEGER, JsonSchema::type)
                 .isInstanceOf(IntegerSchema.class)
@@ -156,7 +161,7 @@ class JsonSchemaGeneratorTest {
                 .returns("int64", IntegerSchema::format);
     }
 
-    @ValueSource(classes = { BigDecimal.class, Number.class })
+    @ValueSource(classes = { BigDecimal.class, BigInteger.class, LongAccumulator.class, Number.class })
     @ParameterizedTest(name = "should generate number schema for \"{0}\"")
     @DisplayName("should generate simple number schema without formats")
     void generatesNumberSchema(Class<?> type) {
@@ -273,8 +278,12 @@ class JsonSchemaGeneratorTest {
         return Stream.of(
                 Arguments.of(UUID.class, "uuid"),
                 Arguments.of(Charset.class, "charset"),
+                Arguments.of(Currency.class, "currency"),
+                Arguments.of(Pattern.class, "regex"),
                 Arguments.of(ZoneId.class, "time-zone"),
                 Arguments.of(TimeZone.class, "time-zone"),
+                Arguments.of(YearMonth.class, "year-month"),
+                Arguments.of(Year.class, "year"),
                 Arguments.of(Locale.class, "language"),
                 Arguments.of(Resource.class, "resource"),
                 Arguments.of(MimeType.class, "mime-type"),


### PR DESCRIPTION
 - Add JSON Schema string formats for `Pattern` (`regex`), `Currency` (`currency`), `Year` (`year`), and `YearMonth` (`year-month`)
  - Give `Short`/`short` their own `int16` integer format instead of grouping them with `BigInteger` as a formatless integer
  - Move `BigInteger` to the `NUMBER` schema type (alongside `BigDecimal`/`Number`) instead of `INTEGER`, following the common OpenAPI/JSON Schema convention that keeps codegen tools from truncating arbitrary-precision values into a bounded integer size
  - Fix a pre-existing test naming bug where the integer test method for `Integer`/`int32` was mislabeled `generatesShortIntegerSchema`
  - Add test coverage for the new formats and for the `Number` fallback path via `LongAccumulator`