### PR TITLE
Add insecure flag to allow plaintext registries behind a private network

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,28 @@ konfigyr {
 You can declare as many registries as you need. Every one gets published to independently. If both
 `clientCredentials { }` and `tokenExchange { }` are configured on the same registry, `tokenExchange` wins.
 
+A registry's `url` must use `https`, unless the host is a loopback address (`localhost`, `127.0.0.1`, `::1`),
+which is exempt for local testing. If you're publishing to a service that's only ever reachable over an
+otherwise secured channel, e.g. one exposed exclusively on a private network or VPN, set `insecure = true`
+to allow a plain `http` URL. Only do this when you're sure the channel itself is trusted, since credentials
+are sent in plaintext:
+
+```kotlin
+konfigyr {
+    registries {
+        registry("internal") {
+            url      = uri("http://konfigyr.internal.acme.com")
+            insecure = true
+
+            clientCredentials {
+                clientId = "acme-corp-client-id"
+                clientSecret = "acme-corp-client-secret"
+            }
+        }
+    }
+}
+```
+
 </details>
 
 <details>

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/AuthorizationServerMetadataResolver.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/AuthorizationServerMetadataResolver.java
@@ -31,7 +31,8 @@ import java.util.Objects;
  * metadata.
  * <p>
  * Every URI involved in discovery must use {@code https}, unless its host is a loopback address
- * ({@code localhost}, {@code 127.0.0.1}, {@code ::1}), which is exempted for local testing.
+ * ({@code localhost}, {@code 127.0.0.1}, {@code ::1}), which is exempted for local testing, or the
+ * resolved {@link Registry#insecure()} is {@literal true}.
  * <p>
  * Results are cached per registry {@code url} for a configurable TTL, defaulting to 15 minutes, so
  * that repeated builds sharing a JVM (e.g., the Gradle daemon) don't re-discover the same registry on
@@ -80,19 +81,22 @@ final class AuthorizationServerMetadataResolver {
     }
 
     /**
-     * Resolves the {@link AuthorizationServerMetadata} for the registry reachable at the given
-     * {@code url}, using a cached result if one is present and not yet expired.
+     * Resolves the {@link AuthorizationServerMetadata} for the given {@link Registry}, using a cached
+     * result if one is present and not yet expired.
      *
-     * @param registryUrl the registry's {@code url}, cannot be {@literal null}.
+     * @param registry the registry to resolve metadata for, cannot be {@literal null}.
      * @return the resolved metadata, never {@literal null}.
      */
-    AuthorizationServerMetadata resolve(URI registryUrl) {
-        Objects.requireNonNull(registryUrl, "registry URL must not be null");
-        return cache.get(registryUrl, () -> discover(registryUrl));
+    AuthorizationServerMetadata resolve(Registry registry) {
+        Objects.requireNonNull(registry, "registry must not be null");
+        return cache.get(registry.host(), () -> discover(registry));
     }
 
-    private AuthorizationServerMetadata discover(URI registryUrl) {
-        assertHttps(registryUrl);
+    private AuthorizationServerMetadata discover(Registry registry) {
+        final URI registryUrl = registry.host();
+        final boolean insecure = registry.insecure();
+
+        assertHttps(registryUrl, insecure);
 
         if (logger.isDebugEnabled()) {
             logger.debug("Discovering OAuth2 Authorization Server Metadata for registry: {}", registryUrl);
@@ -104,7 +108,7 @@ final class AuthorizationServerMetadataResolver {
 
         if (protectedResourceMetadata != null) {
             authorizationServerIssuer = extractAuthorizationServerIssuer(protectedResourceMetadata, registryUrl);
-            assertHttps(authorizationServerIssuer);
+            assertHttps(authorizationServerIssuer, insecure);
         }
 
         final JsonNode authorizationServerMetadata =
@@ -239,17 +243,18 @@ final class AuthorizationServerMetadataResolver {
                 .build();
     }
 
-    private static void assertHttps(URI uri) {
+    static void assertHttps(URI uri, boolean insecure) {
         if ("https".equalsIgnoreCase(uri.getScheme())) {
             return;
         }
 
-        if ("http".equalsIgnoreCase(uri.getScheme()) && isLoopback(uri.getHost())) {
+        if ("http".equalsIgnoreCase(uri.getScheme()) && (isLoopback(uri.getHost()) || insecure)) {
             return;
         }
 
         throw new IllegalArgumentException(
-                "Registry URL '%s' must use HTTPS (loopback addresses are exempt for local testing)".formatted(uri));
+                "Registry URL '%s' must use HTTPS (loopback addresses are exempt for local testing, or set insecure = true to opt out)"
+                        .formatted(uri));
     }
 
     private static boolean isLoopback(@Nullable String host) {

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/DefaultOAuthClientCredentialsProvider.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/DefaultOAuthClientCredentialsProvider.java
@@ -83,7 +83,7 @@ final class DefaultOAuthClientCredentialsProvider implements OAuthClientCredenti
     }
 
     private AccessToken requestToken(Registry registry) {
-        final URI tokenUri = resolver.resolve(registry.host()).tokenEndpoint();
+        final URI tokenUri = resolver.resolve(registry).tokenEndpoint();
 
         if (logger.isDebugEnabled()) {
             logger.debug("Attempting to obtain OAuth2 access token from: {}", tokenUri);

--- a/konfigyr-plugin-core/src/main/java/com/konfigyr/Registry.java
+++ b/konfigyr-plugin-core/src/main/java/com/konfigyr/Registry.java
@@ -20,12 +20,18 @@ import java.util.Objects;
  * @param host        The base URL of the Konfigyr Artifactory API, also used as the discovery seed
  *                    for this registry's OAuth2 endpoints, never {@literal null}.
  * @param credentials Credentials used to authenticate with the Konfigyr Identity Provider, never {@literal null}.
+ * @param insecure    Whether {@code host} is allowed to use the plain {@code http} scheme, beyond the
+ *                    loopback exemption that's always granted for local testing. <strong>Use with
+ *                    caution</strong>: only set this for a registry that's known to be reachable
+ *                    exclusively over an otherwise secured channel, for example a service exposed
+ *                    exclusively on a private network or VPN, since credentials are otherwise sent in
+ *                    plaintext and can be intercepted by anyone on the network path.
  * @author Vladimir Spasic
  * @since 1.0.0
  * @see Credentials
  * @see TransportOptions
  */
-public record Registry(@NonNull URI host, @NonNull Credentials credentials) implements Serializable {
+public record Registry(@NonNull URI host, @NonNull Credentials credentials, boolean insecure) implements Serializable {
 
     @Serial
     private static final long serialVersionUID = 579252712638626059L;
@@ -52,6 +58,7 @@ public record Registry(@NonNull URI host, @NonNull Credentials credentials) impl
     public static final class Builder {
         private URI host = DEFAULT_HOST;
         private Credentials credentials;
+        private boolean insecure = false;
 
         private Builder() {
             // Private constructor to enforce the builder pattern
@@ -91,12 +98,29 @@ public record Registry(@NonNull URI host, @NonNull Credentials credentials) impl
         }
 
         /**
+         * Sets whether {@code host} is allowed to use the plain {@code http} scheme, beyond the
+         * loopback exemption that's always granted for local testing. Defaults to {@literal false}.
+         * <p>
+         * <strong>Use with caution</strong>: only enable this for a registry that's known to be
+         * reachable exclusively over an otherwise secured channel, for example a service exposed
+         * exclusively on a private network or VPN. Credentials are otherwise sent in plaintext and
+         * can be intercepted by anyone on the network path.
+         *
+         * @param insecure {@literal true} to allow a plain {@code http} host.
+         * @return this builder instance for method chaining.
+         */
+        public Builder insecure(boolean insecure) {
+            this.insecure = insecure;
+            return this;
+        }
+
+        /**
          * Constructs a new {@link Registry} instance with the configured values.
          *
          * @return a new registry instance, never {@literal null}.
          */
         public Registry build() {
-            return new Registry(host, credentials);
+            return new Registry(host, credentials, insecure);
         }
     }
 }

--- a/konfigyr-plugin-core/src/test/java/com/konfigyr/AuthorizationServerMetadataResolverTest.java
+++ b/konfigyr-plugin-core/src/test/java/com/konfigyr/AuthorizationServerMetadataResolverTest.java
@@ -22,12 +22,24 @@ class AuthorizationServerMetadataResolverTest extends AbstractWiremockTest {
         resolver = new AuthorizationServerMetadataResolver(JsonMapper.shared(), new Transport(TransportOptions.DEFAULT));
     }
 
+    private static Registry registryFor(URI url) {
+        return registryFor(url, false);
+    }
+
+    private static Registry registryFor(URI url, boolean insecure) {
+        return Registry.builder()
+                .host(url)
+                .credentials(new ClientCredentials("client-id", "client-secret"))
+                .insecure(insecure)
+                .build();
+    }
+
     @Test
     @DisplayName("should resolve metadata directly from the registry when Protected Resource Metadata is absent")
     void resolvesDirectlyWhenProtectedResourceMetadataIsAbsent() {
         final URI registryUrl = URI.create(wiremock.baseUrl());
 
-        final var metadata = resolver.resolve(registryUrl);
+        final var metadata = resolver.resolve(registryFor(registryUrl));
 
         assertThat(metadata.issuer()).isEqualTo(registryUrl);
         assertThat(metadata.tokenEndpoint()).isEqualTo(URI.create(wiremock.baseUrl() + "/oauth/token"));
@@ -57,7 +69,7 @@ class AuthorizationServerMetadataResolverTest extends AbstractWiremockTest {
         wiremock.stubFor(get(urlPathEqualTo("/.well-known/oauth-authorization-server/idp"))
                 .willReturn(jsonResponse(authorizationServerMetadata, 200)));
 
-        final var metadata = resolver.resolve(registryUrl);
+        final var metadata = resolver.resolve(registryFor(registryUrl));
 
         assertThat(metadata.issuer()).isEqualTo(issuer);
         assertThat(metadata.tokenEndpoint()).isEqualTo(URI.create(issuer + "/oauth/token"));
@@ -77,7 +89,7 @@ class AuthorizationServerMetadataResolverTest extends AbstractWiremockTest {
         wiremock.stubFor(get(urlPathEqualTo("/.well-known/oauth-authorization-server/tenant1"))
                 .willReturn(jsonResponse(metadata, 200)));
 
-        final var resolved = resolver.resolve(registryUrl);
+        final var resolved = resolver.resolve(registryFor(registryUrl));
 
         assertThat(resolved.issuer()).isEqualTo(registryUrl);
         assertThat(resolved.tokenEndpoint()).isEqualTo(URI.create(registryUrl + "/oauth/token"));
@@ -97,7 +109,7 @@ class AuthorizationServerMetadataResolverTest extends AbstractWiremockTest {
         wiremock.stubFor(get(urlPathEqualTo("/.well-known/oauth-authorization-server"))
                 .willReturn(jsonResponse(metadata, 200)));
 
-        final var resolved = resolver.resolve(registryUrl);
+        final var resolved = resolver.resolve(registryFor(registryUrl));
 
         assertThat(resolved.issuer()).isEqualTo(registryUrl);
         assertThat(resolved.tokenEndpoint()).isEqualTo(URI.create(registryUrl + "/oauth/token"));
@@ -117,7 +129,7 @@ class AuthorizationServerMetadataResolverTest extends AbstractWiremockTest {
                 .willReturn(jsonResponse(metadata, 200)));
 
         assertThatIllegalStateException()
-                .isThrownBy(() -> resolver.resolve(registryUrl))
+                .isThrownBy(() -> resolver.resolve(registryFor(registryUrl)))
                 .withMessageContaining("does not match the expected issuer");
     }
 
@@ -133,7 +145,7 @@ class AuthorizationServerMetadataResolverTest extends AbstractWiremockTest {
                 .willReturn(jsonResponse(metadata, 200)));
 
         assertThatIllegalStateException()
-                .isThrownBy(() -> resolver.resolve(registryUrl))
+                .isThrownBy(() -> resolver.resolve(registryFor(registryUrl)))
                 .withMessageContaining("missing required field 'token_endpoint'");
     }
 
@@ -146,7 +158,7 @@ class AuthorizationServerMetadataResolverTest extends AbstractWiremockTest {
                 .willReturn(aResponse().withStatus(500)));
 
         assertThatIllegalStateException()
-                .isThrownBy(() -> resolver.resolve(registryUrl))
+                .isThrownBy(() -> resolver.resolve(registryFor(registryUrl)))
                 .withMessageContaining("unexpected HTTP status code 500");
     }
 
@@ -154,8 +166,15 @@ class AuthorizationServerMetadataResolverTest extends AbstractWiremockTest {
     @DisplayName("should reject a non-HTTPS registry URL that is not a loopback address")
     void rejectsNonHttpsNonLoopback() {
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> resolver.resolve(URI.create("http://example.com")))
+                .isThrownBy(() -> resolver.resolve(registryFor(URI.create("http://example.com"))))
                 .withMessageContaining("must use HTTPS");
+    }
+
+    @Test
+    @DisplayName("should allow a non-HTTPS, non-loopback URL when insecure is true")
+    void allowsNonHttpsNonLoopbackWhenInsecure() {
+        assertThatCode(() -> AuthorizationServerMetadataResolver.assertHttps(URI.create("http://example.com"), true))
+                .doesNotThrowAnyException();
     }
 
     @Test
@@ -165,15 +184,16 @@ class AuthorizationServerMetadataResolverTest extends AbstractWiremockTest {
                 JsonMapper.shared(), new Transport(TransportOptions.DEFAULT), Duration.ofMillis(50)
         );
         final URI registryUrl = URI.create(wiremock.baseUrl());
+        final Registry registry = registryFor(registryUrl);
 
-        shortLivedResolver.resolve(registryUrl);
-        shortLivedResolver.resolve(registryUrl);
+        shortLivedResolver.resolve(registry);
+        shortLivedResolver.resolve(registry);
 
         wiremock.verify(1, getRequestedFor(urlPathEqualTo("/.well-known/oauth-authorization-server")));
 
         Thread.sleep(100);
 
-        shortLivedResolver.resolve(registryUrl);
+        shortLivedResolver.resolve(registry);
 
         wiremock.verify(2, getRequestedFor(urlPathEqualTo("/.well-known/oauth-authorization-server")));
     }

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrExtension.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrExtension.java
@@ -62,6 +62,9 @@ import java.time.Duration;
  * Every declared registry receives its own publish/release request when the relevant task runs,
  * there is no "active" or "selected" registry, mirroring how Gradle's own {@code maven-publish}
  * plugin generates one publish task per declared repository.
+ * <p>
+ * A registry's {@code url} must use {@code https}, unless the host is a loopback address, or
+ * {@link RegistrySpec#getInsecure() insecure} is set to {@literal true}.
  *
  * @author Vladimir Spasic
  * @since 1.0.0

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrPlugin.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrPlugin.java
@@ -10,6 +10,8 @@ import org.gradle.api.artifacts.ArtifactCollection;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
@@ -38,6 +40,8 @@ import java.util.*;
 public class KonfigyrPlugin implements Plugin<@NonNull Project> {
 
     static final String PLUGIN_NAME = "konfigyr";
+
+    private static final Logger logger = Logging.getLogger(KonfigyrPlugin.class);
 
     @Override
     public void apply(@NonNull Project project) {
@@ -185,6 +189,17 @@ public class KonfigyrPlugin implements Plugin<@NonNull Project> {
                     "konfigyr { registries { konfigyrCentral() } } (on the root project, or via " +
                     "subprojects{}/allprojects{}), or konfigyr { registries { registry(\"name\") { ... } } }."
             );
+        }
+
+        for (Map.Entry<String, Registry> entry : resolved.entrySet()) {
+            final Registry registry = entry.getValue();
+
+            if (RegistrySpec.isInsecureRegistry(registry)) {
+                logger.warn("Registry '{}' is configured with insecure = true - its url '{}' uses plain HTTP, " +
+                        "sending credentials in plaintext. Only use this for a registry that's reachable " +
+                        "exclusively over an otherwise secured channel, e.g. a private network or VPN.",
+                        entry.getKey(), registry.host());
+            }
         }
 
         return Collections.unmodifiableMap(resolved);

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/RegistrySpec.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/RegistrySpec.java
@@ -62,6 +62,24 @@ import java.net.URI;
  * only exception, resolving unset values from the same {@code KONFIGYR_CLIENT_ID} /
  * {@code KONFIGYR_CLIENT_SECRET} / {@code KONFIGYR_SUBJECT_TOKEN} environment variables the plugin
  * has always supported.
+ * <p>
+ * The {@link #getUrl() url} must use {@code https}, unless the host is a loopback address. A
+ * registry that's only ever reachable over an otherwise secured channel, for example a service
+ * exposed exclusively on a private network or VPN, can opt out of this check with
+ * {@link #getInsecure() insecure}:
+ *
+ * <pre>{@code
+ * registries {
+ *     registry("internal") {
+ *         url      = uri("http://konfigyr.internal.acme.com")
+ *         insecure = true
+ *
+ *         clientCredentials {
+ *             clientId     = "acme-corp-client"
+ *             clientSecret = "acme-corp-secret"
+ *         }
+ *     }
+ * }}</pre>
  *
  * @author Vladimir Spasic
  * @since 1.2.0
@@ -85,9 +103,19 @@ public class RegistrySpec implements Named {
      * The registry's {@code url}. This is the sole discovery seed for this registry: its OAuth2
      * endpoints are resolved from it at build time, and the Artifactory API is reached via fixed
      * relative paths under this same origin. Must use {@code https}, unless the host is a loopback
-     * address, which is only intended for local testing.
+     * address, or {@link #insecure} is set to {@literal true}.
      */
     private final Property<URI> url;
+
+    /**
+     * Whether this registry's {@link #url} is allowed to use the plain {@code http} scheme, beyond
+     * the loopback exemption that's always granted for local testing. Defaults to {@literal false}.
+     * <p>
+     * <strong>Use with caution</strong>: enabling this sends credentials in plaintext, so only set it
+     * for a registry that's known to be reachable exclusively over an otherwise secured channel, for
+     * example a service that's only accessible over a private network or VPN.
+     */
+    private final Property<Boolean> insecure;
 
     @Getter(lombok.AccessLevel.NONE)
     private final ObjectFactory objects;
@@ -126,6 +154,7 @@ public class RegistrySpec implements Named {
         this.useEnvironmentConventions = useEnvironmentConventions;
 
         this.url = objects.property(URI.class);
+        this.insecure = objects.property(Boolean.class).convention(false);
 
         if (useEnvironmentConventions) {
             this.url.convention(Registry.DEFAULT_HOST);
@@ -179,14 +208,10 @@ public class RegistrySpec implements Named {
      * @return the registry, never {@literal null}.
      */
     Registry toRegistry() {
-        KonfigyrExtension.assertPropertySet(url, "url", null);
-
-        final URI registryUrl = url.get();
-        assertHttps(registryUrl);
-
         return Registry.builder()
-                .host(registryUrl)
+                .host(resolveHost())
                 .credentials(resolveCredentials())
+                .insecure(insecure.getOrElse(false))
                 .build();
     }
 
@@ -203,21 +228,49 @@ public class RegistrySpec implements Named {
                 "registries { " + name + " { tokenExchange { } } }.");
     }
 
-    private void assertHttps(URI registryUrl) {
+    private URI resolveHost() {
+        KonfigyrExtension.assertPropertySet(url, "url", null);
+
+        final URI registryUrl = getUrl().get();
+        final boolean insecure = getInsecure().getOrElse(false);
+
         if ("https".equalsIgnoreCase(registryUrl.getScheme())) {
-            return;
+            return registryUrl;
         }
 
-        if ("http".equalsIgnoreCase(registryUrl.getScheme()) && isLoopback(registryUrl.getHost())) {
-            return;
+        if ("http".equalsIgnoreCase(registryUrl.getScheme()) && (isLoopback(registryUrl.getHost()) || insecure)) {
+            return registryUrl;
         }
 
         throw new GradleException("Registry '" + name + "' url '" + registryUrl + "' must use HTTPS " +
-                "(loopback addresses are exempt for local testing).");
+                "(loopback addresses are exempt for local testing, or set insecure = true to opt out).");
     }
 
     private static boolean isLoopback(@Nullable String host) {
         return "localhost".equalsIgnoreCase(host) || "127.0.0.1".equals(host) || "::1".equals(host);
+    }
+
+    /**
+     * Checks whether the given {@link Registry} is actually relying on {@code insecure = true} to
+     * allow a plaintext connection to a real, non-loopback host, as opposed to having the flag set
+     * redundantly on a {@code https} or loopback {@code host}, neither of which carries any real
+     * plaintext risk. Used to decide whether a build-time warning is worth logging for it.
+     *
+     * @param registry the registry to check, cannot be {@literal null}.
+     * @return {@literal true} if the registry's {@code host} is plaintext {@code http} to a
+     *         non-loopback address because {@code insecure} was set to {@literal true}.
+     */
+    static boolean isInsecureRegistry(Registry registry) {
+        if (!registry.insecure()) {
+            return false;
+        }
+        final URI host = registry.host();
+
+        if ("https".equalsIgnoreCase(host.getScheme())) {
+            return false;
+        }
+
+        return !isLoopback(registry.host().getHost());
     }
 
     /**

--- a/konfigyr-plugin-gradle/src/test/java/com/konfigyr/gradle/RegistrySpecTest.java
+++ b/konfigyr-plugin-gradle/src/test/java/com/konfigyr/gradle/RegistrySpecTest.java
@@ -1,5 +1,6 @@
 package com.konfigyr.gradle;
 
+import com.konfigyr.ClientCredentials;
 import com.konfigyr.Registry;
 import com.konfigyr.TokenExchange;
 import org.gradle.api.GradleException;
@@ -190,6 +191,76 @@ class RegistrySpecTest {
         });
 
         assertThat(spec.toRegistry().host()).isEqualTo(URI.create("http://localhost:8080"));
+    }
+
+    @Test
+    @DisplayName("is not insecure by default")
+    void notInsecureByDefault() {
+        final RegistrySpec spec = new RegistrySpec("staging", objects, providers, false);
+
+        assertThat(spec.getInsecure().get()).isFalse();
+    }
+
+    @Test
+    @DisplayName("allows a non-https url when insecure is set to true")
+    void allowsNonHttpsUrlWhenInsecure() {
+        final RegistrySpec spec = new RegistrySpec("staging", objects, providers, false);
+        spec.getUrl().set(URI.create("http://konfigyr.internal.acme.com"));
+        spec.getInsecure().set(true);
+        spec.clientCredentials(credentials -> {
+            credentials.getClientId().set("client-id");
+            credentials.getClientSecret().set("client-secret");
+        });
+
+        assertThat(spec.toRegistry().host())
+                .isEqualTo(URI.create("http://konfigyr.internal.acme.com"));
+    }
+
+    @Test
+    @DisplayName("isInsecureRegistry is false when insecure is not set")
+    void isInsecureRegistryFalseWhenNotInsecure() {
+        final Registry registry = Registry.builder()
+                .host(URI.create("http://konfigyr.internal.acme.com"))
+                .credentials(new ClientCredentials("client-id", "client-secret"))
+                .build();
+
+        assertThat(RegistrySpec.isInsecureRegistry(registry)).isFalse();
+    }
+
+    @Test
+    @DisplayName("isInsecureRegistry is false when insecure is set but the host uses https")
+    void isInsecureRegistryFalseWhenHttps() {
+        final Registry registry = Registry.builder()
+                .host(URI.create("https://konfigyr.internal.acme.com"))
+                .credentials(new ClientCredentials("client-id", "client-secret"))
+                .insecure(true)
+                .build();
+
+        assertThat(RegistrySpec.isInsecureRegistry(registry)).isFalse();
+    }
+
+    @Test
+    @DisplayName("isInsecureRegistry is false when insecure is set but the host is a loopback address")
+    void isInsecureRegistryFalseWhenLoopback() {
+        final Registry registry = Registry.builder()
+                .host(URI.create("http://localhost:8080"))
+                .credentials(new ClientCredentials("client-id", "client-secret"))
+                .insecure(true)
+                .build();
+
+        assertThat(RegistrySpec.isInsecureRegistry(registry)).isFalse();
+    }
+
+    @Test
+    @DisplayName("isInsecureRegistry is true when insecure is set on a plaintext, non-loopback host")
+    void isInsecureRegistryTrueForRealInsecureHost() {
+        final Registry registry = Registry.builder()
+                .host(URI.create("http://konfigyr.internal.acme.com"))
+                .credentials(new ClientCredentials("client-id", "client-secret"))
+                .insecure(true)
+                .build();
+
+        assertThat(RegistrySpec.isInsecureRegistry(registry)).isTrue();
     }
 
 }


### PR DESCRIPTION
## Summary

- Add an `insecure` opt-out on `RegistrySpec`/`Registry` for registries that can only be reached over plain HTTP (e.g. a Konfigyr service behind a VPN/private network with no HTTPS available), while keeping the existing HTTPS requirement as the default for everyone else.
- Thread the flag through OAuth2 Authorization Server Metadata discovery (`AuthorizationServerMetadataResolver`), which previously enforced HTTPS independently of `RegistrySpec` and would have rejected an insecure registry's token discovery even after `RegistrySpec` allowed its URL.
- Log a build-time warning, once per registry, when `insecure = true` is actually being relied upon to allow a plaintext connection to a real (non-loopback) host — not when it's redundantly set on an `https` URL or a loopback address, since neither carries real plaintext risk.

## Details

- `Registry` (core record): new `insecure` component (default `false`), builder support, and Javadoc warning that credentials are sent in plaintext when enabled.
- `RegistrySpec` (Gradle DSL): new `insecure` property (`Property<Boolean>`, default `false`); `resolveHost()` allows `http` when either the host is a loopback address or `insecure = true`; `toRegistry()` propagates the flag into the built `Registry`.
- `RegistrySpec.isInsecureRegistry(Registry)`: package-private helper that distinguishes a registry genuinely relying on the flag from a redundant/harmless case (`https` URL, or loopback host).
- `AuthorizationServerMetadataResolver`: `resolve`/`discover` now take the full `Registry` instead of a bare `URI`, so its own `assertHttps` check (now package-private for direct unit testing) can honor `registry.insecure()` at both discovery checkpoints — the registry URL and the authorization-server issuer extracted from RFC 9728 metadata.
- `DefaultOAuthClientCredentialsProvider`: passes `registry` straight through to the resolver.
- `KonfigyrPlugin`: after resolving the deduplicated, build-wide registry map, logs `logger.warn(...)` for each registry where `RegistrySpec.isInsecureRegistry(...)` is true — guaranteed once per registry per build, since it runs against the final deduplicated map rather than inside `toRegistry()` (which can be invoked more than once per registry during resolution).
- `README.md` / `KonfigyrExtension` Javadoc updated with the new `insecure` property and an example.

## Usage

```kotlin
konfigyr {
    registries {
        registry("internal") {
            url      = uri("http://konfigyr.internal.acme.com")
            insecure = true

            clientCredentials {
                clientId     = "acme-corp-client-id"
                clientSecret = "acme-corp-client-secret"
            }
        }
    }
}