### PR TITLE
Add per-registry `publishTo<Registry>` grouping task

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,13 +256,16 @@ fails rather than silently skipping, see the FAQ below.
 <details>
 <summary><strong>Tasks</strong></summary>
 
-The plugin registers one publish/release task pair **per declared registry**, plus a shared `konfigyr`
-umbrella task. For a registry named `staging`, the publish task is `publishArtifactMetadataToStaging`; for
-the reserved `konfigyrCentral` registry, it's `publishArtifactMetadataToKonfigyrCentral`, and so on.
+The plugin registers one publish/release task pair **per declared registry**, grouped under a per-registry
+`publishTo<Registry>` task, plus a shared `konfigyr` umbrella task that depends on every registry's grouping
+task. For a registry named `staging`, the publish task is `publishArtifactMetadataToStaging` and the grouping
+task is `publishToStaging`; for the reserved `konfigyrCentral` registry, it's `publishArtifactMetadataToKonfigyrCentral`
+and `publishToKonfigyrCentral`, and so on.
 
 | Task | Scenario | Runs when |
 |---|---|---|
-| `konfigyr` | Both | Always. Depends on every registry's publish/release tasks below. |
+| `konfigyr` | Both | Always. Depends on every registry's `publishTo<Registry>` task below. |
+| `publishTo<Registry>` | Both | Always. Depends on `<Registry>`'s own publish/release tasks below. |
 | `generateArtifactMetadata` | Shared | Always. Scans this project's own built jar; feeds both scenarios. Cacheable. |
 | `publishArtifactMetadataTo<Registry>` | Direct publish | Whenever `<Registry>` has a `url` and a grant configured. |
 | `resolveServiceDependencies` | Service release | Only if `service { }` is configured. Cacheable. |
@@ -275,6 +278,9 @@ the project's own jar exposes configuration metadata; otherwise it's a no-op.
 You can run any task individually, e.g. `./gradlew generateArtifactMetadata` to scan and write metadata
 locally with no network calls. Generated files live under `build/konfigyr/` and are fully cacheable.
 Re-running without classpath changes is instant.
+
+To publish and release to just one registry without touching the others, run its `publishTo<Registry>` task,
+e.g. `./gradlew publishToStaging` runs both `publishArtifactMetadataToStaging` and `createServiceReleaseToStaging`.
 
 </details>
 

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrPlugin.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrPlugin.java
@@ -26,10 +26,11 @@ import java.util.*;
 /**
  * Gradle plugin for publishing Spring Boot configuration metadata to Konfigyr.
  * <p>
- * Registers a {@code konfigyr} meta-task, and one publish/release task pair per registry declared in
- * the {@link KonfigyrExtension#getRegistries() registries} container - there is no single "the"
- * registry or connection, every declared registry gets its own task pair and its own {@link Registry}
- * connection, keyed by registry name.
+ * Registers a {@code konfigyr} meta-task, and, per registry declared in the
+ * {@link KonfigyrExtension#getRegistries() registries} container, a {@code publishTo<Registry>}
+ * grouping task depending on that registry's own publish/release task pair. There is no single "the"
+ * registry or connection, every declared registry gets its own grouping task, task pair, and its own
+ * {@link Registry} connection, keyed by registry name.
  * <p>
  * You can configure the plugin using the {@code konfigyr} extension.
  *
@@ -63,19 +64,26 @@ public class KonfigyrPlugin implements Plugin<@NonNull Project> {
         // register konfigyr meta-task that would be used as the main entrypoint...
         final TaskProvider<DefaultTask> meta = project.getTasks().register(PLUGIN_NAME, DefaultTask.class, task -> {
             task.setGroup(PLUGIN_NAME);
-            task.setDescription("Task that would generate and publish the Konfigyr artifact metadata for your project");
+            task.setDescription("Generates and publishes the Konfigyr artifact metadata to every configured registry, creating a " +
+                    "service release wherever a service is also configured. Requires at least one registry to be " +
+                    "declared, or the build fails.");
         });
 
         // ...and one publish/release task pair per registry this project declares, registered lazily as
-        // each registry is added to the container, so declaration order relative to plugin application
+        // each registry is added to the container, so declaration order relative to the plugin application
         // doesn't matter.
         extension.getRegistries().all(registry -> {
+            // registers a registry-specific publishing meta-task that would be used to
+            // group both publish and release tasks for the same registry
+            final TaskProvider<DefaultTask> publishToRegistry = registerPublishToRegistryTask(project, registry);
+
             final Provider<PublishArtifactMetadataTask> publishMetadataTask =
                     registerPublishMetadataTask(project, extension, service, generateMetadataTask, registry);
             final Provider<CreateServiceReleaseTask> createReleaseTask =
                     registerCreateServiceReleaseTask(project, extension, service, generateMetadataTask, resolveDependenciesTask, registry);
 
-            meta.configure(task -> task.dependsOn(publishMetadataTask, createReleaseTask));
+            publishToRegistry.configure(task -> task.dependsOn(publishMetadataTask, createReleaseTask));
+            meta.configure(task -> task.dependsOn(publishToRegistry));
         });
     }
 
@@ -249,6 +257,18 @@ public class KonfigyrPlugin implements Plugin<@NonNull Project> {
     }
 
     @NullMarked
+    private static TaskProvider<DefaultTask> registerPublishToRegistryTask(Project project, RegistrySpec registry) {
+        final String registryName = registry.getName();
+        final String taskName = "publishTo" + capitalize(registryName);
+
+        return project.getTasks().register(taskName, DefaultTask.class, task -> {
+            task.setGroup(PLUGIN_NAME);
+            task.setDescription("Generates and publishes the Konfigyr artifact metadata to registry '" +
+                    registryName + "', creating a service release too wherever a service is also configured.");
+        });
+    }
+
+    @NullMarked
     private static Provider<PublishArtifactMetadataTask> registerPublishMetadataTask(
             Project project,
             KonfigyrExtension extension,
@@ -270,7 +290,9 @@ public class KonfigyrPlugin implements Plugin<@NonNull Project> {
             task.usesService(service);
 
             task.setGroup(PLUGIN_NAME);
-            task.setDescription("Publishes this project's own artifact metadata directly to registry '" + registryName + "'");
+            task.setDescription("Publishes this project's own artifact metadata directly to registry '" + registryName + "', " +
+                    "independently of any service release. Skipped unless registry '" + registryName + "' declares a " +
+                    "url and authentication credentials.");
 
             task.dependsOn(generateMetadataTask);
 
@@ -298,7 +320,8 @@ public class KonfigyrPlugin implements Plugin<@NonNull Project> {
             task.usesService(service);
 
             task.setGroup(PLUGIN_NAME);
-            task.setDescription("Resolves this service's dependencies that expose Spring Boot configuration metadata");
+            task.setDescription("Resolves this service's dependencies that expose Spring Boot configuration metadata. Skipped " +
+                    "unless a service is configured.");
 
             task.onlyIf(
                     "the service { } block must be configured to create a service release",
@@ -331,7 +354,9 @@ public class KonfigyrPlugin implements Plugin<@NonNull Project> {
             task.usesService(service);
 
             task.setGroup(PLUGIN_NAME);
-            task.setDescription("Creates a Service Release for this service on registry '" + registryName + "', uploading required artifact metadata");
+            task.setDescription("Creates a Service Release for this service on registry '" + registryName + "', uploading required " +
+                    "artifact metadata. Skipped unless a service is configured and registry '" + registryName + "' " +
+                    "declares a url and authentication credentials.");
 
             task.onlyIf(
                     "the service { } block must be configured, and registry '" + registryName + "' must be " +

--- a/konfigyr-plugin-gradle/src/test/java/com/konfigyr/gradle/KonfigyrPluginApplicationTest.java
+++ b/konfigyr-plugin-gradle/src/test/java/com/konfigyr/gradle/KonfigyrPluginApplicationTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class KonfigyrPluginApplicationTest {
 
+    private static final String PUBLISH_TO_REGISTRY_TASK = "publishToKonfigyrCentral";
     private static final String PUBLISH_TASK = PublishArtifactMetadataTask.NAME + "ToKonfigyrCentral";
     private static final String CREATE_RELEASE_TASK = CreateServiceReleaseTask.NAME + "ToKonfigyrCentral";
 
@@ -87,6 +88,14 @@ class KonfigyrPluginApplicationTest {
 
         assertThat(project.getTasks().getByName(KonfigyrPlugin.PLUGIN_NAME))
                 .as("Should register %s task", KonfigyrPlugin.PLUGIN_NAME)
+                .extracting(Task::getDependsOn, InstanceOfAssertFactories.iterable(TaskProvider.class))
+                .extracting(TaskProvider::getName)
+                .containsExactlyInAnyOrder(PUBLISH_TO_REGISTRY_TASK);
+
+        assertThat(project.getTasks().getByName(PUBLISH_TO_REGISTRY_TASK))
+                .as("Should register %s task", PUBLISH_TO_REGISTRY_TASK)
+                .isNotNull()
+                .returns(KonfigyrPlugin.PLUGIN_NAME, Task::getGroup)
                 .extracting(Task::getDependsOn, InstanceOfAssertFactories.iterable(TaskProvider.class))
                 .extracting(TaskProvider::getName)
                 .containsExactlyInAnyOrder(PUBLISH_TASK, CREATE_RELEASE_TASK);


### PR DESCRIPTION
Adds a `publishTo<Registry>` grouping task per declared registry, so a single registry's publish and release
tasks can be run together without touching any other registry.

- Previously the `konfigyr` umbrella task depended directly on each registry's `publishArtifactMetadataTo<Registry>`
  and `createServiceReleaseTo<Registry>` tasks. There was no way to target just one registry short of invoking
  its two leaf tasks by name.
- `konfigyr` now depends on each registry's new `publishTo<Registry>` task, which in turn depends on that
  registry's publish/release pair, e.g. `./gradlew publishToStaging` runs both `publishArtifactMetadataToStaging`
  and `createServiceReleaseToStaging`.
- Tightened up several task descriptions (`konfigyr`, `publishArtifactMetadataTo<Registry>`,
  `resolveServiceDependencies`, `createServiceReleaseTo<Registry>`) to state their skip conditions in plain
  language, and updated the class Javadoc to describe the new grouping task.
- Updated the README's Tasks table and surrounding prose to document the new task and naming convention.
