### PR TITLE
Make the metadata artifact view lenient to tolerate jar-less dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ subprojects {
     }
 
     group = "com.konfigyr"
-    version = "1.2.0"
+    version = "1.2.1"
 
     java {
         withJavadocJar()

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrPlugin.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/KonfigyrPlugin.java
@@ -385,10 +385,23 @@ public class KonfigyrPlugin implements Plugin<@NonNull Project> {
         return project.getConfigurations()
                 .getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
                 .getIncoming()
-                .artifactView(view -> view.attributes(attributes -> attributes.attribute(
-                        ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE,
-                        ArtifactMetadataTransform.ARTIFACT_TYPE
-                )))
+                .artifactView(view -> {
+                    // Some published components declare a transitive dependency that has no jar
+                    // variant at all (e.g., a Maven parent/aggregator POM, or non-jar packaging
+                    // such as a "documentation" or "samples" zip). ArtifactMetadataTransform's
+                    // @InputArtifactDependencies requires a jar for every such node to build its
+                    // reflection classpath, which fails the whole resolution even though the
+                    // dependent artifact's own runtime classpath entry resolves fine. Since a
+                    // dependency that can't be transformed simply contributes no metadata, the
+                    // same way one without any Spring Boot configuration metadata does, this view
+                    // is lenient: failures are skipped here and surfaced as a warning in
+                    // ResolveServiceDependenciesTask instead of failing the build.
+                    view.lenient(true);
+                    view.attributes(attributes -> attributes.attribute(
+                            ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE,
+                            ArtifactMetadataTransform.ARTIFACT_TYPE
+                    ));
+                })
                 .getArtifacts();
     }
 

--- a/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ResolveServiceDependenciesTask.java
+++ b/konfigyr-plugin-gradle/src/main/java/com/konfigyr/gradle/ResolveServiceDependenciesTask.java
@@ -132,8 +132,15 @@ public abstract class ResolveServiceDependenciesTask extends DefaultTask {
     void resolveServiceDependencies() throws IOException {
         final List<String> locations = new ArrayList<>();
         final ArtifactoryService service = getService().get();
+        final ArtifactCollection artifacts = getArtifacts().get();
 
-        getArtifacts().get().forEach(artifact -> {
+        artifacts.getFailures().forEach(failure -> {
+            getLogger().warn("Could not resolve Konfigyr metadata for a runtime classpath dependency, it will be " +
+                    "skipped from this service's dependency manifest: {}", failure.getMessage());
+            getLogger().debug("Stack trace for failed dependency", failure);
+        });
+
+        artifacts.forEach(artifact -> {
             final Artifact candidate = createArtifact(artifact.getId());
 
             if (candidate == null) {


### PR DESCRIPTION
Some published dependencies have no jar variant at all (a Maven parent/aggregator POM, or a "documentation"/"samples" zip artifact type). `ArtifactMetadataTransform`'s `@InputArtifactDependencies` requires a jar for every such node to build its reflection classpath, which was failing `resolveServiceDependencies` for the whole project even though the dependent artifact's own runtime classpath entry resolved fine.
